### PR TITLE
Switch to pynput module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ piper_voices/*
 !piper_voices/en_US-amy-medium.onnx
 test.ipynb
 config.py
+venv/*

--- a/EXAMPLE.config.py
+++ b/EXAMPLE.config.py
@@ -55,9 +55,10 @@ OPENAI_VOICE = "nova"
 ACTIVE_PROMPT = "default_prompt" #Right now there is only 1 prompt
 
 ### HOTKEYS ###
-CANCEL_HOTKEY = 'ctrl + alt + x'
-CLEAR_HISTORY_HOTKEY = 'ctrl + alt + f12'
-RECORD_HOTKEY = 'ctrl + shift + space'
+CANCEL_HOTKEY = '<ctrl>+<alt>+x'
+CLEAR_HISTORY_HOTKEY = '<ctrl>+<alt>+c'
+RECORD_HOTKEY = '<ctrl>+<alt>+r'
+
 
 ### MISC ###
 HOTKEY_DELAY = 0.5

--- a/TTS.py
+++ b/TTS.py
@@ -38,7 +38,7 @@ class TTS:
         # Delete any leftover temp files if any
         for file in os.listdir(config.AUDIO_FILE_DIR):
             if file.endswith(".wav"):
-                os.remove(f"{config.AUDIO_FILE_DIR}\\{file}")
+                os.remove(os.path.join(config.AUDIO_FILE_DIR,file))
 
     def wait(self):
         """
@@ -251,7 +251,7 @@ class TTS:
         try:
             for file in os.listdir(config.AUDIO_FILE_DIR):
                 if file.endswith(".wav"):
-                    os.remove(f"{config.AUDIO_FILE_DIR}\\{file}")
+                    os.remove(os.path.join(config.AUDIO_FILE_DIR,file))
         except Exception as e:
             print(f"Error deleting leftover files: {e}")
 

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import time
 import threading
 from audio_recorder import AudioRecorder
 from transcriber import TranscriptionManager
-import keyboard
+from pynput import keyboard
 import TTS
 from chat_completions import CompletionManager
 from soundfx import play_sound_FX
@@ -271,18 +271,17 @@ class Recorder:
 
     def run(self):
         """Run the recorder, setting up hotkeys and entering the main loop."""
-        keyboard.add_hotkey(config.RECORD_HOTKEY, self.handle_hotkey_wrapper)
-        keyboard.add_hotkey(config.CANCEL_HOTKEY, self.cancel_all)
-        keyboard.add_hotkey(config.CLEAR_HISTORY_HOTKEY, self.clear_messages)
         print(f"Press '{config.RECORD_HOTKEY}' to start recording, press again to stop and transcribe.\nDouble tap to give the AI access to read your clipboard.\nPress '{config.CANCEL_HOTKEY}' to cancel recording.\nPress '{config.CLEAR_HISTORY_HOTKEY}' to clear the chat history.")
-
-        try:
-            while True:
-                time.sleep(0.0001)
-        except KeyboardInterrupt:
-            print("Recorder stopped by user.")
-        except Exception as e:
-            print(f"An error occurred: {e}")
+        with keyboard.GlobalHotKeys({
+                config.RECORD_HOTKEY: self.handle_hotkey_wrapper,
+                config.CANCEL_HOTKEY: self.cancel_all,
+                config.CLEAR_HISTORY_HOTKEY: self.clear_messages}) as hotkey_listener:
+            try:
+                hotkey_listener.join()
+            except KeyboardInterrupt:
+                print("Recorder stopped by user.")
+            except Exception as e:
+                print(f"An error occurred: {e}")
 
 if __name__ == "__main__":
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 anthropic
 clipboard
-keyboard
+pynput
 numpy
 openai
 pydub

--- a/transcription_apis/whisperx_api.py
+++ b/transcription_apis/whisperx_api.py
@@ -10,7 +10,7 @@ class WhisperXClient:
         self.compute_type = "int8"
         self.language = config.TRANSCRIPTION_LANGUAGE
         self.model = wx.load_model(config.WHISPER_MODEL, self.device, language=self.language, compute_type=self.compute_type, download_root=config.WHISPER_MODEL_PATH)
-        print(f"Using WhisperX model: {self.model} and device: {self.device}")
+        print(f"Using WhisperX model: {config.WHISPER_MODEL} and device: {self.device}")
 
     def transcribe_audio_file(self, file_path):
         print(f"Transcribing audio file: {file_path}")


### PR DESCRIPTION
This PR switches to the pynput module to handle hotkeys. This will enable to run AlwaysReddy as a non-root user. 
For issue https://github.com/ILikeAI/AlwaysReddy/issues/11

Limitations:
- pynput cannot handle space and tab for hotkeys.
- The default Ctrl-Alt-F12 in linux is captured to switch console and cannot be used.
- It only works for X. XWayland can only handle the hotkeys in it´s own window. Otherwise on Wayland the application needs to be run as root either way.

And it also adds my venv to .gitignore, which I thought I kept outside of the feature branch... It is a good practice to use python venv's for your (dev) environments anyway. 

