### PR TITLE
print model from config

### DIFF
--- a/transcription_apis/whisperx_api.py
+++ b/transcription_apis/whisperx_api.py
@@ -10,7 +10,7 @@ class WhisperXClient:
         self.compute_type = "int8"
         self.language = config.TRANSCRIPTION_LANGUAGE
         self.model = wx.load_model(config.WHISPER_MODEL, self.device, language=self.language, compute_type=self.compute_type, download_root=config.WHISPER_MODEL_PATH)
-        print(f"Using WhisperX model: {self.model} and device: {self.device}")
+        print(f"Using WhisperX model: {config.WHISPER_MODEL} and device: {self.device}")
 
     def transcribe_audio_file(self, file_path):
         print(f"Transcribing audio file: {file_path}")


### PR DESCRIPTION
This is just a small change to print the whisper model from `config` rather than `self.model`. Model prints its memory address I think. I checked the available attributes and none of them returns the actual model name. Printing from config seems to be the only option here.