### PR TITLE
ignore MacOS directory files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test.ipynb
 config.py
 /venv
 test.py
+.DS_Store
 
 # Ignore everything in the piper_tts directory
 /piper_tts/*

--- a/audio_recorder.py
+++ b/audio_recorder.py
@@ -47,7 +47,7 @@ class AudioRecorder:
     def record_audio(self):
         """Records audio from the default input device."""
         try:
-            with sd.InputStream(samplerate=config.FS, channels=2, dtype='float32', callback=self.callback):
+            with sd.InputStream(samplerate=config.FS, channels=1, dtype='float32', callback=self.callback):
                 while self.recording:
                     sd.sleep(100)
         except Exception as e:


### PR DESCRIPTION
.DS_Store files are created for every MacOS directory. They are unique to each Mac and should be ignored here.