### PR TITLE
Add config option to suppress native hotkey functionality (Windows only)

### DIFF
--- a/EXAMPLE.config
+++ b/EXAMPLE.config
@@ -68,6 +68,7 @@ ACTIVE_PROMPT = "default_prompt" #Right now there is only 1 prompt
 CANCEL_HOTKEY = 'alt+ctrl+e'
 CLEAR_HISTORY_HOTKEY = 'alt+ctrl+w'
 RECORD_HOTKEY = 'alt+ctrl+r'
+SUPPRESS_NATIVE_HOTKEYS = True # Suppress the native system functionality of the defined hotkeys above (Windows only)
 
 
 ### MISC ###

--- a/keyboard_handler.py
+++ b/keyboard_handler.py
@@ -46,7 +46,7 @@ class KeyboardHandler:
 
 class KeyboardLibraryHandler(KeyboardHandler):
     def add_hotkey(self, hotkey, callback):
-        keyboard.add_hotkey(hotkey, callback)
+        keyboard.add_hotkey(hotkey, callback, suppress=config.SUPPRESS_NATIVE_HOTKEYS)
 
     def start(self):
         try:

--- a/keyboard_handler.py
+++ b/keyboard_handler.py
@@ -46,7 +46,7 @@ class KeyboardHandler:
 
 class KeyboardLibraryHandler(KeyboardHandler):
     def add_hotkey(self, hotkey, callback):
-        keyboard.add_hotkey(hotkey, callback, suppress=config.SUPPRESS_NATIVE_HOTKEYS)
+        keyboard.add_hotkey(hotkey, callback, suppress=getattr(config, 'SUPPRESS_NATIVE_HOTKEYS', False))
 
     def start(self):
         try:

--- a/soundfx.py
+++ b/soundfx.py
@@ -74,8 +74,6 @@ def play_sound_FX(name, volume=1.0, verbose=False):
         sound_thread = threading.Thread(target=play_sound_file, args=(sound_file_name, volume, verbose))
         sound_thread.start()
 
-        if platform.system() != "Windows":
-            sound_thread.join()  # Wait for the thread to complete
     except Exception as e:
         if verbose:
             import traceback

--- a/soundfx.py
+++ b/soundfx.py
@@ -6,6 +6,7 @@ import time
 import pyaudio
 import wave
 import numpy as np
+import platform
 
 def play_sound_file(file_name, volume, verbose=False):
     try:
@@ -72,7 +73,9 @@ def play_sound_FX(name, volume=1.0, verbose=False):
 
         sound_thread = threading.Thread(target=play_sound_file, args=(sound_file_name, volume, verbose))
         sound_thread.start()
-        sound_thread.join()  # Wait for the thread to complete
+
+        if platform.system() != "Windows":
+            sound_thread.join()  # Wait for the thread to complete
     except Exception as e:
         if verbose:
             import traceback


### PR DESCRIPTION
For people who want to use other hotkeys that have conflicting native functionality. Enabled by default because I think it's safe to assume that most users don't want their AlwaysReddy hotkeys to simultaneously trigger other stuff.

Only added support for Windows since pynput does not seem to support key suppression.