### PR TITLE
Reset last_message_was_cut_off on clear_messages()

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ class AlwaysReddy:
         # TODO Eventually i would like to keep track of conversations and be able to switch between them
         print("Clearing messages...")
         self.messages = prompts[config.ACTIVE_PROMPT]["messages"].copy()
+        self.last_message_was_cut_off = False
 
     def was_double_tapped(self, threshold=0.2):
         """


### PR DESCRIPTION
When the user clears the history, last_message_was_cut_off should reset to False so the AI doesn't get told that it was cut off in the next fresh conversation, since it doesn't know what was said previously anyway.