### PR TITLE
Remove getattr from keyboard_handler

### DIFF
--- a/keyboard_handler.py
+++ b/keyboard_handler.py
@@ -46,7 +46,7 @@ class KeyboardHandler:
 
 class KeyboardLibraryHandler(KeyboardHandler):
     def add_hotkey(self, hotkey, callback):
-        keyboard.add_hotkey(hotkey, callback, suppress=getattr(config, 'SUPPRESS_NATIVE_HOTKEYS', False))
+        keyboard.add_hotkey(hotkey, callback, suppress=config.SUPPRESS_NATIVE_HOTKEYS)
 
     def start(self):
         try:


### PR DESCRIPTION
No longer needed with the new config loader.