### PR TITLE
Add record hotkey double tap delay option

### DIFF
--- a/config_default.py
+++ b/config_default.py
@@ -72,11 +72,12 @@ ACTIVE_PROMPT = "default_prompt" #Right now there is only 1 prompt
 CANCEL_HOTKEY = 'alt+ctrl+e'
 CLEAR_HISTORY_HOTKEY = 'alt+ctrl+w'
 RECORD_HOTKEY = 'alt+ctrl+r'
+
+RECORD_HOTKEY_DELAY = 0.2 # Seconds to wait for RECORD_HOTKEY double tap before starting recording
 SUPPRESS_NATIVE_HOTKEYS = True # Suppress the native system functionality of the defined hotkeys above (Windows only)
 
 
 ### MISC ###
-HOTKEY_DELAY = 0.5
 AUDIO_FILE_DIR = "audio_files"
 MAX_TOKENS = 8000 #Max tokens allowed in memory at once
 START_SEQ = "-CLIPSTART-" #the model is instructed to place any text for the clipboard between the start and end seq

--- a/main.py
+++ b/main.py
@@ -259,7 +259,7 @@ class AlwaysReddy:
         """
         Wrapper for the hotkey handler to include double tap detection for clipboard usage.
         """
-        use_clipboard = self.was_double_tapped()
+        use_clipboard = self.was_double_tapped(config.RECORD_HOTKEY_DELAY)
         if self.verbose:
             print("use_clipboard:", use_clipboard)
         if use_clipboard:
@@ -277,7 +277,7 @@ class AlwaysReddy:
             self.timer = None
             self.start_main_thread()
         else:
-            self.timer = threading.Timer(0.2, self.start_main_thread)
+            self.timer = threading.Timer(config.RECORD_HOTKEY_DELAY, self.start_main_thread)
             self.timer.start()
 
     def run(self):


### PR DESCRIPTION
`config.HOTKEY_DELAY` exists already, which I assume was meant to control the double tap delay for activating the clipboard injection, but it has not actually been implemented.

This pull request renames it to `config.RECORD_HOTKEY_DELAY` and implements it. The default value has been changed to what the double tap logic already used (0.2s), so the default behaviour remains the same.