### PR TITLE
Push-to-talk + pynput fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ Set VERBOSE = True in the config to get more detailed logs and error traces
 There are currently only main 2 actions:
 
 Voice chat:
-- Press `Ctrl + Alt + R`  to start dictating, you can talk for as long as you want, then press `Ctrl + Alt + R` again to stop recording, a few seconds later you will get a voice response from the AIal
+- Press `Ctrl + Alt + R`  to start dictating, you can talk for as long as you want, then press `Ctrl + Alt + R` again to stop recording, a few seconds later you will get a voice response from the AI
+- You can also hold `Ctrl + Alt + R` to record and release it when you're done to get the transcription.
 
 Voice chat with context of your clipboard:
 - Double tap `Ctrl + Alt + R` (or just hold `Ctrl + Alt` and quickly press `R` Twice) This will give the AI the content of your clipboard so you can ask it to reference it, rewrite it, answer questions from its contents... whatever you like! 

--- a/config_default.py
+++ b/config_default.py
@@ -69,9 +69,12 @@ OPENAI_VOICE = "nova"
 ACTIVE_PROMPT = "default_prompt" #Right now there is only 1 prompt
 
 ### HOTKEYS ###
+# Hotkeys can be set to None to disable them
 CANCEL_HOTKEY = 'alt+ctrl+e'
 CLEAR_HISTORY_HOTKEY = 'alt+ctrl+w'
-RECORD_HOTKEY = 'alt+ctrl+r'
+RECORD_HOTKEY = 'alt+ctrl+r' # Press to start, press again to stop, double tap to start using clipboard
+RECORD_HELD_HOTKEY = None # Hold down to start, release to stop (push-to-talk)
+RECORD_HELD_CLIPBOARD_HOTKEY = None # Same as above, but also use clipboard
 
 RECORD_HOTKEY_DELAY = 0.2 # Seconds to wait for RECORD_HOTKEY double tap before starting recording
 SUPPRESS_NATIVE_HOTKEYS = True # Suppress the native system functionality of the defined hotkeys above (Windows only)

--- a/config_default.py
+++ b/config_default.py
@@ -72,9 +72,7 @@ ACTIVE_PROMPT = "default_prompt" #Right now there is only 1 prompt
 # Hotkeys can be set to None to disable them
 CANCEL_HOTKEY = 'alt+ctrl+e'
 CLEAR_HISTORY_HOTKEY = 'alt+ctrl+w'
-RECORD_HOTKEY = 'alt+ctrl+r' # Press to start, press again to stop, double tap to start using clipboard
-RECORD_HELD_HOTKEY = None # Hold down to start, release to stop (push-to-talk)
-RECORD_HELD_CLIPBOARD_HOTKEY = None # Same as above, but also use clipboard
+RECORD_HOTKEY = 'alt+ctrl+r' # Press to start, press again to stop, or hold and release. Double tap to include clipboard
 
 RECORD_HOTKEY_DELAY = 0.2 # Seconds to wait for RECORD_HOTKEY double tap before starting recording
 SUPPRESS_NATIVE_HOTKEYS = True # Suppress the native system functionality of the defined hotkeys above (Windows only)

--- a/keyboard_handler.py
+++ b/keyboard_handler.py
@@ -45,8 +45,22 @@ class KeyboardHandler:
         raise NotImplementedError("start method must be implemented in subclasses")
 
 class KeyboardLibraryHandler(KeyboardHandler):
+    def __init__(self, verbose=False):
+        super().__init__(verbose)
+        self.held_hotkeys = {}
+
     def add_hotkey(self, hotkey, callback):
         keyboard.add_hotkey(hotkey, callback, suppress=config.SUPPRESS_NATIVE_HOTKEYS)
+
+    def add_held_hotkey(self, hotkey, callback):
+        self.held_hotkeys[hotkey] = False
+        keyboard.add_hotkey(hotkey, lambda: self.handle_held_callback(hotkey, callback, is_pressed=True), suppress=config.SUPPRESS_NATIVE_HOTKEYS)
+        keyboard.add_hotkey(hotkey, lambda: self.handle_held_callback(hotkey, callback, is_pressed=False), suppress=config.SUPPRESS_NATIVE_HOTKEYS, trigger_on_release=True)
+
+    def handle_held_callback(self, hotkey, callback, is_pressed):
+        if is_pressed != self.held_hotkeys[hotkey]:
+            callback(is_pressed=is_pressed)
+            self.held_hotkeys[hotkey] = is_pressed
 
     def start(self):
         try:

--- a/keyboard_handler.py
+++ b/keyboard_handler.py
@@ -4,35 +4,8 @@ import platform
 operating_system = platform.system()
 if operating_system == "Windows":
     import keyboard
-
 else:
     from pynput import keyboard as pynput_keyboard
-
-    
-
-def convert_to_pynput_format(hotkey):
-    """Convert a keyboard module style hotkey to a pynput style hotkey."""
-    parts = hotkey.split('+')
-    converted = []
-    for part in parts:
-        part = part.strip().lower()
-        if part == 'ctrl':
-            converted.append('<ctrl>')
-        elif part == 'shift':
-            converted.append('<shift>')
-        elif part == 'alt':
-            converted.append('<alt>')
-        elif part == 'windows' or part == 'cmd' or part == 'left windows':  # Handling Windows or Command key
-            converted.append('<cmd>')  # Use <win> if <cmd> does not work
-        else:
-            converted.append(part)
-    return '+'.join(converted)
-
-def check_space_usage(hotkey):
-    """Check if 'space' is used in the hotkey and print a warning if so."""
-    if 'space' in hotkey.split('+'):
-        print("\nWARNING: 'space' key does not work on linux systems with pynput library. "
-              "To set a new hotkey run the 'hotkey_config_GUI.py' script.\n")
 
 class KeyboardHandler:
     def __init__(self, verbose=False):
@@ -40,6 +13,9 @@ class KeyboardHandler:
 
     def add_hotkey(self, hotkey, callback):
         raise NotImplementedError("add_hotkey method must be implemented in subclasses")
+
+    def add_held_hotkey(self, hotkey, callback):
+        raise NotImplementedError("add_held_hotkey method must be implemented in subclasses")
 
     def start(self):
         raise NotImplementedError("start method must be implemented in subclasses")
@@ -79,27 +55,113 @@ class KeyboardLibraryHandler(KeyboardHandler):
 class PynputHandler(KeyboardHandler):
     def __init__(self, verbose=False):
         super().__init__(verbose)
-        self.hotkey_map = {}
+        self.hotkeys: list = []
+        self.listener = pynput_keyboard.Listener(on_press=self.pressed, on_release=self.released)
+
+    class HotKey(object):
+        """Reimplementation of pynput's HotKey class.
+
+        Adds on_release callback and return boolean whether hotkey was activated or deactivated.
+        """
+
+        def __init__(self, keys, on_press, on_release=None):
+            self._state = set()
+            self._keys = set(keys)
+            self._on_press = on_press
+            self._on_release = on_release
+            self.pressed = False
+
+        def combination_length(self):
+            return len(self._keys)
+
+        def press(self, key):
+            if key in self._keys and key not in self._state:
+                self._state.add(key)
+                if self._state == self._keys:
+                    self.pressed = True
+                    if self._on_press:
+                        self._on_press()
+                    return True
+            return False
+
+        def release(self, key):
+            if key in self._state:
+                self._state.remove(key)
+                if self.pressed:
+                    self.pressed = False
+                    if self._on_release:
+                        self._on_release()
+                    return True
+            return False
+
+    @staticmethod
+    def convert_to_pynput_format(hotkey):
+        """Convert a keyboard module style hotkey to a pynput style hotkey."""
+        parts = hotkey.split('+')
+        converted = []
+        for part in parts:
+            part = part.strip().lower()
+            if part == 'win' or part == 'windows' or part == 'left windows':  # Handling Windows or Command key
+                converted.append('<cmd>')  # Use <win> if <cmd> does not work
+            if part == 'capslock':
+                converted.append('<caps_lock>')
+            elif len(part) > 1:
+                converted.append(f'<{part}>')
+            else:
+                converted.append(part)
+        return '+'.join(converted)
+
+    def _add_hotkey(self, hotkey, press_callback, release_callback):
+        converted_hotkey = PynputHandler.convert_to_pynput_format(hotkey)  # Convert hotkey to pynput format
+        try:
+            keys = [self.listener.canonical(key) for key in pynput_keyboard.HotKey.parse(converted_hotkey)]
+            self.hotkeys.append(PynputHandler.HotKey(keys, press_callback, release_callback))
+        except ValueError:
+            print(f"\nERROR: hotkey '{hotkey}' is not supported by pynput library."
+                  "\nTo set a new hotkey, run the 'hotkey_config_GUI.py' script or edit your 'config.py' file.\n")
+            raise
 
     def add_hotkey(self, hotkey, callback):
-        # Convert hotkey to pynput format
-        pynput_hotkey = convert_to_pynput_format(hotkey)
-        check_space_usage(hotkey)  # Check for space usage
-        self.hotkey_map[pynput_hotkey] = callback
+        self._add_hotkey(hotkey, callback, None)
+
+    def add_held_hotkey(self, hotkey, callback):
+        """Callback must be a function that takes is_pressed as a boolean argument.
+        """
+        self._add_hotkey(hotkey, lambda: callback(is_pressed=True), lambda: callback(is_pressed=False))
+
+    def pressed(self, key):
+        # If a hotkey is already pressed, don't activate any other
+        for hotkey in self.hotkeys:
+            if hotkey.pressed:
+                return
+
+        key = self.listener.canonical(key)
+        for hotkey in self.hotkeys:
+            if hotkey.press(key):
+                break
+
+    def released(self, key):
+        key = self.listener.canonical(key)
+        for hotkey in self.hotkeys:
+            hotkey.release(key)
 
     def start(self):
-        with pynput_keyboard.GlobalHotKeys(self.hotkey_map) as hotkey_listener:
-            try:
-                hotkey_listener.join()
-            except KeyboardInterrupt:
-                if self.verbose:
-                    print("Recorder stopped by user.")
-            except Exception as e:
-                if self.verbose:
-                    import traceback
-                    traceback.print_exc()
-                else:
-                    print(f"An error occurred: {e}")
+        try:
+            # Sort hotkeys by number of keys in combination, so most complicated combinations are first
+            # that way we can prioritize the most complex combination when there is a conflict
+            self.hotkeys.sort(key=lambda hotkey: hotkey.combination_length(), reverse=True)
+
+            with self.listener:
+                self.listener.join()
+        except KeyboardInterrupt:
+            if self.verbose:
+                print("Recorder stopped by user.")
+        except Exception as e:
+            if self.verbose:
+                import traceback
+                traceback.print_exc()
+            else:
+                print(f"An error occurred: {e}")
 
 def get_keyboard_handler(verbose=False):
     if operating_system == "Windows":

--- a/main.py
+++ b/main.py
@@ -25,7 +25,6 @@ class AlwaysReddy:
         self.completion_client = CompletionManager(TTS_client=self.tts, parent_client=self, verbose=self.verbose)
         self.tts.completion_client = self.completion_client
         self.recording_stop_time = None
-        self.timer = None
         self.main_thread = None
         self.stop_response = False
         self.last_message_was_cut_off = False
@@ -36,21 +35,6 @@ class AlwaysReddy:
         print("Clearing messages...")
         self.messages = prompts[config.ACTIVE_PROMPT]["messages"].copy()
         self.last_message_was_cut_off = False
-
-    def was_double_tapped(self, threshold=0.2):
-        """
-        Check if the hotkey was double tapped within a given threshold.
-
-        Args:
-            threshold (float): The time threshold for double tapping.
-
-        Returns:
-            bool: True if double tapped, False otherwise.
-        """
-        current_time = time.time()
-        double_tapped = current_time - self.last_press_time < threshold
-        self.last_press_time = current_time
-        return double_tapped
 
     def start_recording(self):
         """Start the audio recording process and set a timeout for automatic stopping."""
@@ -241,23 +225,19 @@ class AlwaysReddy:
 
     def start_main_thread(self):
         """This starts the main thread and keeps a reference to it."""
-        self.timer = None
-
         if self.main_thread is not None and self.main_thread.is_alive():
             # If the thread is already running, cancel (without playing cancel sound) and start a new one
             self.cancel_all(silent=True)  # the silence is just so you dont hear cancel sound immediately followed by the start sound
             self.main_thread.join()
 
-            self.main_thread = threading.Thread(target=self.handle_hotkey)
-            self.main_thread.start()
-
-        else:
-            self.main_thread = threading.Thread(target=self.handle_hotkey)
-            self.main_thread.start()
+        self.main_thread = threading.Thread(target=self.handle_hotkey)
+        self.main_thread.start()
 
     def use_clipboard(self):
         try:
             self.clipboard_text = read_clipboard()
+            if self.verbose:
+                print("Using clipboard...")
         except Exception as e:
             if self.verbose:
                 import traceback
@@ -265,38 +245,20 @@ class AlwaysReddy:
             else:
                 print(f"Failed to read from clipboard: {e}")
 
-    def handle_hotkey_wrapper(self):
+    def handle_hotkey_wrapper(self, is_pressed):
         """
-        Wrapper for the hotkey handler to include double tap detection for clipboard usage.
+        Wrapper for the hotkey handler to handle push-to-talk and double tap detection for clipboard usage.
         """
-        use_clipboard = self.was_double_tapped(config.RECORD_HOTKEY_DELAY)
-        if self.verbose:
-            print("use_clipboard:", use_clipboard)
-        if use_clipboard:
-            self.use_clipboard()
-
-        if self.timer is not None:
-            self.timer.cancel()
-            self.timer = None
-            self.start_main_thread()
-        else:
-            self.timer = threading.Timer(config.RECORD_HOTKEY_DELAY, self.start_main_thread)
-            self.timer.start()
-
-    def handle_held_hotkey_wrapper(self, is_pressed):
-        """
-        Wrapper for the held (push-to-talk) hotkey handler.
-        """
-        self.start_main_thread()
-
-    def handle_held_clipboard_hotkey_wrapper(self, is_pressed):
-        """
-        Wrapper for the held (push-to-talk) hotkey handler with clipboard usage.
-        """
+        within_delay = time.time() - self.last_press_time < config.RECORD_HOTKEY_DELAY
         if is_pressed:
-            self.use_clipboard()
-
-        self.start_main_thread()
+            self.last_press_time = time.time()
+            if self.is_recording and within_delay:
+                self.use_clipboard()
+                return
+            self.start_main_thread() # start recording
+        else:
+            if self.is_recording and not within_delay:
+                self.start_main_thread() # stop recording
 
     def run(self):
         """Run the recorder, setting up hotkeys and entering the main loop."""
@@ -304,16 +266,10 @@ class AlwaysReddy:
 
         print()
         if config.RECORD_HOTKEY:
-            keyboard_handler.add_hotkey(config.RECORD_HOTKEY, self.handle_hotkey_wrapper)
-            print(f"Press '{config.RECORD_HOTKEY}' to start recording, press again to stop and transcribe.\n\tDouble tap to give AlwaysReddy the content currently copied in your clipboard.")
-
-        if config.RECORD_HELD_HOTKEY:
-            keyboard_handler.add_held_hotkey(config.RECORD_HELD_HOTKEY, self.handle_held_hotkey_wrapper)
-            print(f"Hold '{config.RECORD_HELD_HOTKEY}' to start recording, release to stop and transcribe.")
-
-        if config.RECORD_HELD_CLIPBOARD_HOTKEY:
-            keyboard_handler.add_held_hotkey(config.RECORD_HELD_CLIPBOARD_HOTKEY, self.handle_held_clipboard_hotkey_wrapper)
-            print(f"Hold '{config.RECORD_HELD_CLIPBOARD_HOTKEY}' to start recording, release to stop and transcribe\n\tand give AlwaysReddy the content currently copied in your clipboard.")
+            keyboard_handler.add_held_hotkey(config.RECORD_HOTKEY, self.handle_hotkey_wrapper)
+            print(f"Press '{config.RECORD_HOTKEY}' to start recording, press again to stop and transcribe."
+                  f"\n\tAlternatively hold it down to record until you release."
+                  f"\n\tDouble tap to give AlwaysReddy the content currently copied in your clipboard.")
 
         if config.CANCEL_HOTKEY:
             keyboard_handler.add_hotkey(config.CANCEL_HOTKEY, self.cancel_all)


### PR DESCRIPTION
This pull request adds a few input-related features and fixes:
- Support for held hotkeys (add_held_hotkey()).
- RECORD_HOTKEY can alternatively be held down to record until it is released (push-to-talk).
- The time the hotkey waits to detect a double tap for clipboard usage no longer delays when the recording start, making it more reponsive.
- Support for unbound hotkeys (set to None). Both the new hotkeys are set to None by default. Unbound hotkeys will not be listed in the terminal.
- Fixes to pynput (Linux/Mac).
  - Support overlapping hotkeys: Can bind Shift+Ctrl+R to one thing and Shift+R to another, and then trigger the first without also triggering the second.
  - Support for many more keys like Space, Capslock, Esc, F-keys, etc.

PynputHandler has been largely rewritten, because to support this stuff I needed to move away from using GlobalHotKeys().

With this I think pynput on Linux/Mac should be functionally equivalent to the keyboard package on Windows, except for key suppression.