### PR TITLE
Changed keyboard handler to AutoHotKey for better compatibility on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# AutoHotkey-Compatible Version (Windows-Only)
+The original version messed with my other keybinds so I changed over all the keyboard handling functions to AutoHotKey using the ahk Python wrapper.
+- Also adds the ability to use mouse buttons as hotkeys.
+
+---
+
 # Welcome to AlwaysReddy 🔊
 Hey, I'm Josh, the creator of AlwaysReddy. I am still a little bit of a noob when it comes to programming and I'm really trying to develop my skills over the next year, I'm treating this project as an attempt to better develop my skills, with that in mind I would really appreciate it if you could point out issues and bad practices in my code (of which I'm sure there will be plenty). I would also appreciate if you would make your own improvements to the project so I can learn from your changes. Twitter: https://twitter.com/MindofMachine1
 

--- a/config_default.py
+++ b/config_default.py
@@ -7,6 +7,7 @@ USE_GPU = False  # Set to True to use GPU acceleration. Refer to the README for 
 ### COMPLETIONS API SETTINGS  ###
 # Just uncomment the ONE api you want to use
 
+
 ### LOCAL OPTIONS ###
 
 ## OLLAMA COMPLETIONS API EXAMPLE ##
@@ -42,13 +43,13 @@ COMPLETION_MODEL = "gpt-4-0125-preview"
 # COMPLETIONS_API = "openrouter"
 # COMPLETION_MODEL = "openai/gpt-3.5-turbo"
 
+
 ### Transcription API Settings ###
 
 ## Faster Whisper local transcription ###
 # TRANSCRIPTION_API = "FasterWhisper" # this will use the local whisper model
 # WHISPER_MODEL = "tiny.en" # If you prefer not to use english set it to "tiny", if the transcription quality is too low then set it to "base" but this will be a little slower
 # BEAM_SIZE = 5
-
 
 ## Transformers Whisper local transcription ###
 # TRANSCRIPTION_API = "TransformersWhisper"
@@ -58,23 +59,25 @@ COMPLETION_MODEL = "gpt-4-0125-preview"
 TRANSCRIPTION_API = "openai" # this will use the hosted openai api
 
 
-
 ### TTS SETTINGS ###
 TTS_ENGINE="openai" # 'piper' or 'openai' or 'mac'(mac is only for macos)
 
 PIPER_VOICE = "default_female_voice"
 OPENAI_VOICE = "nova"
 
+
 ### PROMPTS ###
 ACTIVE_PROMPT = "default_prompt" #Right now there is only 1 prompt
 
-# uses AHK keycodes
+
+### HOTKEYS ###
+# Hotkeys can be set to None to disable them
+# for more info on hotkey syntax, see: https://www.autohotkey.com/docs/Hotkeys.htm and https://www.autohotkey.com/docs/v1/KeyList.htm
+# note: native hotkeys are suppressed by default.  you can pass through the native functions by adding a "~" to the beginning of the hotkey (e.g. '~^XButton2')
 CANCEL_HOTKEY = '^XButton2'
-CLEAR_HISTORY_HOTKEY = '^!#XButton1' 
-RECORD_MODIFIER = 'Control' # press and hold only works with ahk if there is a modifier to release as it doesn't detect regular key releases.  This modifier should be used in the RECORD_HOTKEY variable.
+CLEAR_HISTORY_HOTKEY = '^!#XButton1'
 RECORD_HOTKEY = '^XButton1' # Press to start, press again to stop, or hold and release. Double tap to include clipboard
-RECORD_HOTKEY_DELAY = 0.2 # Seconds to wait for RECORD_HOTKEY double tap before starting recording
-SUPPRESS_NATIVE_HOTKEYS = True # Suppress the native system functionality of the defined hotkeys above (Windows only)
+RECORD_HOTKEY_DELAY = 0.5 # Seconds to wait for RECORD_HOTKEY double tap before starting recording
 
 
 ### MISC ###

--- a/config_default.py
+++ b/config_default.py
@@ -70,9 +70,10 @@ ACTIVE_PROMPT = "default_prompt" #Right now there is only 1 prompt
 
 ### HOTKEYS ###
 # Hotkeys can be set to None to disable them
-CANCEL_HOTKEY = 'alt+ctrl+e'
-CLEAR_HISTORY_HOTKEY = 'alt+ctrl+w'
-RECORD_HOTKEY = 'alt+ctrl+r' # Press to start, press again to stop, or hold and release. Double tap to include clipboard
+# AHK-Mod: Use keycodes from https://www.autohotkey.com/docs/Hotkeys.htm
+CANCEL_HOTKEY = '^XButton2'
+CLEAR_HISTORY_HOTKEY = '^!#XButton1' 
+RECORD_HOTKEY = '^XButton1' # Press to start, press again to stop, or hold and release. Double tap to include clipboard
 
 RECORD_HOTKEY_DELAY = 0.2 # Seconds to wait for RECORD_HOTKEY double tap before starting recording
 SUPPRESS_NATIVE_HOTKEYS = True # Suppress the native system functionality of the defined hotkeys above (Windows only)

--- a/config_default.py
+++ b/config_default.py
@@ -68,13 +68,11 @@ OPENAI_VOICE = "nova"
 ### PROMPTS ###
 ACTIVE_PROMPT = "default_prompt" #Right now there is only 1 prompt
 
-### HOTKEYS ###
-# Hotkeys can be set to None to disable them
-# AHK-Mod: Use keycodes from https://www.autohotkey.com/docs/Hotkeys.htm
+# uses AHK keycodes
 CANCEL_HOTKEY = '^XButton2'
 CLEAR_HISTORY_HOTKEY = '^!#XButton1' 
+RECORD_MODIFIER = 'Control' # press and hold only works with ahk if there is a modifier to release as it doesn't detect regular key releases.  This modifier should be used in the RECORD_HOTKEY variable.
 RECORD_HOTKEY = '^XButton1' # Press to start, press again to stop, or hold and release. Double tap to include clipboard
-
 RECORD_HOTKEY_DELAY = 0.2 # Seconds to wait for RECORD_HOTKEY double tap before starting recording
 SUPPRESS_NATIVE_HOTKEYS = True # Suppress the native system functionality of the defined hotkeys above (Windows only)
 

--- a/main.py
+++ b/main.py
@@ -250,7 +250,6 @@ class AlwaysReddy:
         Wrapper for the hotkey handler to handle push-to-talk and double tap detection for clipboard usage.
         """
         within_delay = time.time() - self.last_press_time < config.RECORD_HOTKEY_DELAY
-        
         if is_pressed:
             self.last_press_time = time.time()
             if self.is_recording and within_delay:
@@ -260,31 +259,24 @@ class AlwaysReddy:
         else:
             if self.is_recording and not within_delay:
                 self.start_main_thread() # stop recording
-
+    
     def run(self):
         """Run the recorder, setting up hotkeys and entering the main loop."""
-        self.ahk = AHK()  # Store AHK instance as a class attribute
-
+        self.ahk = AHK()                                                                # store AHK instance as a class attribute
         if config.RECORD_HOTKEY:
             self.record_hotkey_held = False
-            print(f"Press '{config.RECORD_HOTKEY}' to start recording, press again to stop and transcribe."
-                  f"\n\tAlternatively hold it down to record until you release."
-                  f"\n\tDouble tap to give AlwaysReddy the content currently copied in your clipboard.")
-            
             def _ahk_hotkey_callback():
                 if not self.record_hotkey_held:
                     self.record_hotkey_held = True
-                    self.handle_hotkey_wrapper(True)  # Trigger on key down
-
-                    # Loop to check for key release
-                    while self.ahk.key_state(config.RECORD_MODIFIER, mode='P'):
-                        time.sleep(0.1)
-
-                    # Hotkey is released
+                    self.handle_hotkey_wrapper(True)                                    # trigger on key down
+                else:
                     self.record_hotkey_held = False
-                    self.handle_hotkey_wrapper(False)  # Trigger on key up
-                    
-            self.ahk.add_hotkey(config.RECORD_HOTKEY, _ahk_hotkey_callback)
+                    self.handle_hotkey_wrapper(False)                                   # trigger on key up
+            self.ahk.add_hotkey(config.RECORD_HOTKEY, _ahk_hotkey_callback)             # keydown
+            self.ahk.add_hotkey(config.RECORD_HOTKEY + " Up", _ahk_hotkey_callback)     # keyup
+            print(f"Press '{config.RECORD_HOTKEY}' to start recording, press again to stop and transcribe."
+                  f"\n\tAlternatively hold it down to record until you release."
+                  f"\n\tDouble tap to give AlwaysReddy the content currently copied in your clipboard.")
 
         if config.CANCEL_HOTKEY:
             self.ahk.add_hotkey(config.CANCEL_HOTKEY, self.cancel_all)
@@ -294,8 +286,8 @@ class AlwaysReddy:
             self.ahk.add_hotkey(config.CLEAR_HISTORY_HOTKEY, self.clear_messages)
             print(f"Press '{config.CLEAR_HISTORY_HOTKEY}' to clear the chat history.")
 
-        self.ahk.start_hotkeys()
-        self.ahk.block_forever()
+        self.ahk.start_hotkeys()                                                        # start hotkey process thread
+        self.ahk.block_forever()                                                        # prevent process from exiting 
 
 if __name__ == "__main__":
     try:

--- a/main.py
+++ b/main.py
@@ -2,13 +2,14 @@ import time
 import threading
 from audio_recorder import AudioRecorder
 from transcriber import TranscriptionManager
-from keyboard_handler import get_keyboard_handler
+# from keyboard_handler import get_keyboard_handler
 import TTS
 from chat_completions import CompletionManager
 from soundfx import play_sound_FX
 from utils import read_clipboard, count_tokens, trim_messages
 from config_loader import config
 from prompt import prompts
+from ahk import AHK
 
 class AlwaysReddy:
     def __init__(self):
@@ -262,24 +263,25 @@ class AlwaysReddy:
 
     def run(self):
         """Run the recorder, setting up hotkeys and entering the main loop."""
-        keyboard_handler = get_keyboard_handler(verbose=self.verbose)
+        ahk = AHK()
 
         print()
         if config.RECORD_HOTKEY:
-            keyboard_handler.add_held_hotkey(config.RECORD_HOTKEY, self.handle_hotkey_wrapper)
+            ahk.key_down(config.RECORD_HOTKEY, self.handle_hotkey_wrapper)
             print(f"Press '{config.RECORD_HOTKEY}' to start recording, press again to stop and transcribe."
                   f"\n\tAlternatively hold it down to record until you release."
                   f"\n\tDouble tap to give AlwaysReddy the content currently copied in your clipboard.")
 
         if config.CANCEL_HOTKEY:
-            keyboard_handler.add_hotkey(config.CANCEL_HOTKEY, self.cancel_all)
+            ahk.add_hotkey(config.CANCEL_HOTKEY, self.cancel_all)
             print(f"Press '{config.CANCEL_HOTKEY}' to cancel recording.")
 
         if config.CLEAR_HISTORY_HOTKEY:
-            keyboard_handler.add_hotkey(config.CLEAR_HISTORY_HOTKEY, self.clear_messages)
+            ahk.add_hotkey(config.CLEAR_HISTORY_HOTKEY, self.clear_messages)
             print(f"Press '{config.CLEAR_HISTORY_HOTKEY}' to clear the chat history.")
 
-        keyboard_handler.start()
+        ahk.start_hotkeys()  # start the hotkey process thread
+        ahk.block_forever()  # stops the script from exiting
 
 if __name__ == "__main__":
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ soundfile
 tiktoken
 requests
 PyAudio
+ahk


### PR DESCRIPTION
The keyboard handler used before was breaking all sorts of keybinds I use, plus it didn't seem to have the ability to bind mouse buttons, so I adapted it and changed everything to use the ahk AutoHotKey Python wrapper.  So far, it works seamlessly with my multitude of other hotkey scripts running. Obviously this is Windows-only, so perhaps you can merge and create an installer step to ask if the user is running Linux, which would revert to the original handler.