### PR TITLE
Input refactor + AutoHotkey handler for Windows

### DIFF
--- a/input_apis/autohotkey_handler.py
+++ b/input_apis/autohotkey_handler.py
@@ -1,0 +1,59 @@
+from input_apis.input_handler import InputHandler
+import config
+from ahk import AHK
+
+class AutohotkeyHandler(InputHandler):
+    def __init__(self, verbose=False):
+        super().__init__(verbose)
+        self.ahk = AHK()
+        self.held_hotkeys = {}
+
+    pynput_modifier_remap = {
+        'shift': '+',
+        'ctrl': '^',
+        'alt': '!',
+        'win': '#',
+        'cmd': '#',
+    }
+
+    def convert_to_autohotkey_format(self, hotkey):
+        parts = hotkey.lower().split('+')
+        modifiers = [part for part in parts if part in self.pynput_modifier_remap]
+        non_modifiers = [part for part in parts if part not in self.pynput_modifier_remap]
+
+        if len(non_modifiers) > 1:
+            print("\nToo many non-modifiers in hotkey: " + hotkey)
+            print("More than one non-modifier is not supported.")
+            return
+
+        translated_hotkey = ''
+
+        for i, modifier in enumerate(modifiers):
+            if len(non_modifiers) > 0 or i < len(modifiers) - 1:
+                translated_hotkey += self.pynput_modifier_remap[modifier]
+            else:
+                translated_hotkey += modifier
+
+        if len(non_modifiers) > 0:
+            translated_hotkey += non_modifiers[0]
+
+        return translated_hotkey
+
+    def add_hotkey(self, hotkey, callback):
+        hotkey = self.convert_to_autohotkey_format(hotkey)
+        self.ahk.add_hotkey(hotkey, callback)
+
+    def add_held_hotkey(self, hotkey, callback):
+        hotkey = self.convert_to_autohotkey_format(hotkey)
+        self.held_hotkeys[hotkey] = False
+        self.ahk.add_hotkey(hotkey, lambda: self.handle_held_callback(hotkey, callback, is_pressed=True))
+        self.ahk.add_hotkey(hotkey + " Up", lambda: self.handle_held_callback(hotkey, callback, is_pressed=False))
+
+    def handle_held_callback(self, hotkey, callback, is_pressed):
+        if is_pressed != self.held_hotkeys[hotkey]:
+            callback(is_pressed=is_pressed)
+            self.held_hotkeys[hotkey] = is_pressed
+
+    def start(self):
+        self.ahk.start_hotkeys()
+        self.ahk.block_forever()

--- a/input_apis/input_handler.py
+++ b/input_apis/input_handler.py
@@ -1,0 +1,26 @@
+import platform
+
+class InputHandler:
+    def __init__(self, verbose=False):
+        self.verbose = verbose
+
+    def add_hotkey(self, hotkey, callback):
+        raise NotImplementedError("add_hotkey method must be implemented in subclasses")
+
+    def add_held_hotkey(self, hotkey, callback):
+        raise NotImplementedError("add_held_hotkey method must be implemented in subclasses")
+
+    def start(self):
+        raise NotImplementedError("start method must be implemented in subclasses")
+
+def get_input_handler(verbose=False):
+    if platform.system() == "Windows":
+        from input_apis.keyboard_library_handler import KeyboardLibraryHandler
+        return KeyboardLibraryHandler(verbose)
+    else:
+        from input_apis.pynput_handler import PynputHandler
+        return PynputHandler(verbose)
+
+
+
+

--- a/input_apis/input_handler.py
+++ b/input_apis/input_handler.py
@@ -15,8 +15,8 @@ class InputHandler:
 
 def get_input_handler(verbose=False):
     if platform.system() == "Windows":
-        from input_apis.keyboard_library_handler import KeyboardLibraryHandler
-        return KeyboardLibraryHandler(verbose)
+        from input_apis.autohotkey_handler import AutohotkeyHandler
+        return AutohotkeyHandler(verbose)
     else:
         from input_apis.pynput_handler import PynputHandler
         return PynputHandler(verbose)

--- a/input_apis/keyboard_library_handler.py
+++ b/input_apis/keyboard_library_handler.py
@@ -1,0 +1,35 @@
+from input_apis.input_handler import InputHandler
+import keyboard
+import config
+
+class KeyboardLibraryHandler(InputHandler):
+    def __init__(self, verbose=False):
+        super().__init__(verbose)
+        self.held_hotkeys = {}
+
+    def add_hotkey(self, hotkey, callback):
+        keyboard.add_hotkey(hotkey, callback, suppress=config.SUPPRESS_NATIVE_HOTKEYS)
+
+    def add_held_hotkey(self, hotkey, callback):
+        self.held_hotkeys[hotkey] = False
+        keyboard.add_hotkey(hotkey, lambda: self.handle_held_callback(hotkey, callback, is_pressed=True), suppress=config.SUPPRESS_NATIVE_HOTKEYS)
+        keyboard.add_hotkey(hotkey, lambda: self.handle_held_callback(hotkey, callback, is_pressed=False), suppress=config.SUPPRESS_NATIVE_HOTKEYS, trigger_on_release=True)
+
+    def handle_held_callback(self, hotkey, callback, is_pressed):
+        if is_pressed != self.held_hotkeys[hotkey]:
+            callback(is_pressed=is_pressed)
+            self.held_hotkeys[hotkey] = is_pressed
+
+    def start(self):
+        try:
+            while True:
+                keyboard.wait()
+        except KeyboardInterrupt:
+            if self.verbose:
+                print("Recorder stopped by user.")
+        except Exception as e:
+            if self.verbose:
+                import traceback
+                traceback.print_exc()
+            else:
+                print(f"An error occurred: {e}")

--- a/input_apis/pynput_handler.py
+++ b/input_apis/pynput_handler.py
@@ -1,58 +1,7 @@
-from config_loader import config
-import platform
+from input_apis.input_handler import InputHandler
+import pynput.keyboard as pynput_keyboard
 
-operating_system = platform.system()
-if operating_system == "Windows":
-    import keyboard
-else:
-    from pynput import keyboard as pynput_keyboard
-
-class KeyboardHandler:
-    def __init__(self, verbose=False):
-        self.verbose = verbose
-
-    def add_hotkey(self, hotkey, callback):
-        raise NotImplementedError("add_hotkey method must be implemented in subclasses")
-
-    def add_held_hotkey(self, hotkey, callback):
-        raise NotImplementedError("add_held_hotkey method must be implemented in subclasses")
-
-    def start(self):
-        raise NotImplementedError("start method must be implemented in subclasses")
-
-class KeyboardLibraryHandler(KeyboardHandler):
-    def __init__(self, verbose=False):
-        super().__init__(verbose)
-        self.held_hotkeys = {}
-
-    def add_hotkey(self, hotkey, callback):
-        keyboard.add_hotkey(hotkey, callback, suppress=config.SUPPRESS_NATIVE_HOTKEYS)
-
-    def add_held_hotkey(self, hotkey, callback):
-        self.held_hotkeys[hotkey] = False
-        keyboard.add_hotkey(hotkey, lambda: self.handle_held_callback(hotkey, callback, is_pressed=True), suppress=config.SUPPRESS_NATIVE_HOTKEYS)
-        keyboard.add_hotkey(hotkey, lambda: self.handle_held_callback(hotkey, callback, is_pressed=False), suppress=config.SUPPRESS_NATIVE_HOTKEYS, trigger_on_release=True)
-
-    def handle_held_callback(self, hotkey, callback, is_pressed):
-        if is_pressed != self.held_hotkeys[hotkey]:
-            callback(is_pressed=is_pressed)
-            self.held_hotkeys[hotkey] = is_pressed
-
-    def start(self):
-        try:
-            while True:
-                keyboard.wait()
-        except KeyboardInterrupt:
-            if self.verbose:
-                print("Recorder stopped by user.")
-        except Exception as e:
-            if self.verbose:
-                import traceback
-                traceback.print_exc()
-            else:
-                print(f"An error occurred: {e}")
-
-class PynputHandler(KeyboardHandler):
+class PynputHandler(InputHandler):
     def __init__(self, verbose=False):
         super().__init__(verbose)
         self.hotkeys: list = []
@@ -162,13 +111,3 @@ class PynputHandler(KeyboardHandler):
                 traceback.print_exc()
             else:
                 print(f"An error occurred: {e}")
-
-def get_keyboard_handler(verbose=False):
-    if operating_system == "Windows":
-        return KeyboardLibraryHandler(verbose)
-    else:
-        return PynputHandler(verbose)
-
-
-
-

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import time
 import threading
 from audio_recorder import AudioRecorder
 from transcriber import TranscriptionManager
-from keyboard_handler import get_keyboard_handler
+from input_apis.input_handler import get_input_handler
 import TTS
 from chat_completions import CompletionManager
 from soundfx import play_sound_FX
@@ -262,24 +262,24 @@ class AlwaysReddy:
 
     def run(self):
         """Run the recorder, setting up hotkeys and entering the main loop."""
-        keyboard_handler = get_keyboard_handler(verbose=self.verbose)
+        input_handler = get_input_handler(verbose=self.verbose)
 
         print()
         if config.RECORD_HOTKEY:
-            keyboard_handler.add_held_hotkey(config.RECORD_HOTKEY, self.handle_hotkey_wrapper)
+            input_handler.add_held_hotkey(config.RECORD_HOTKEY, self.handle_hotkey_wrapper)
             print(f"Press '{config.RECORD_HOTKEY}' to start recording, press again to stop and transcribe."
                   f"\n\tAlternatively hold it down to record until you release."
                   f"\n\tDouble tap to give AlwaysReddy the content currently copied in your clipboard.")
 
         if config.CANCEL_HOTKEY:
-            keyboard_handler.add_hotkey(config.CANCEL_HOTKEY, self.cancel_all)
+            input_handler.add_hotkey(config.CANCEL_HOTKEY, self.cancel_all)
             print(f"Press '{config.CANCEL_HOTKEY}' to cancel recording.")
 
         if config.CLEAR_HISTORY_HOTKEY:
-            keyboard_handler.add_hotkey(config.CLEAR_HISTORY_HOTKEY, self.clear_messages)
+            input_handler.add_hotkey(config.CLEAR_HISTORY_HOTKEY, self.clear_messages)
             print(f"Press '{config.CLEAR_HISTORY_HOTKEY}' to clear the chat history.")
 
-        keyboard_handler.start()
+        input_handler.start()
 
 if __name__ == "__main__":
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ soundfile
 tiktoken
 requests
 PyAudio
+ahk ; sys_platform == 'win32'
+ahk[binary] ; sys_platform == 'win32'


### PR DESCRIPTION
- keyboard_handler has been refactored into a module named input_apis, where each api is a self-contained file. Changed word 'keyboard' to 'input' since AutoHotkey has mouse support, which should be added to pynput_handler as well.
- Implemented [AutoHotkey wrapper](https://github.com/spyoungtech/ahk) as a more reliable replacement to the keyboard package on Windows. (Thanks to @j4byers)
- AutoHotkey uses very different hotkey syntax, for example instead of `ctrl+shift+r` it does `+^r`. So I wrote a hotkey string conversion function so we can keep using the same old hotkey style. Needs more testing.
- The AutoHotkey package is added to requirements.txt with `sys_platform == 'win32'` to only install on Windows.