### PR TITLE
Add config option PIPER_VOICE_INDEX to support multi-voice piper models

### DIFF
--- a/TTS_apis/piper_tts_client.py
+++ b/TTS_apis/piper_tts_client.py
@@ -63,7 +63,8 @@ class PiperTTSClient:
                 piper_binary,
                 "-m", model_path,
                 "-c", json_path,
-                "-f", output_file
+                "-f", output_file,
+                "-s", str(config.PIPER_VOICE_INDEX)
             ]
             process = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=(None if self.verbose else subprocess.DEVNULL), stderr=subprocess.STDOUT)
             process.communicate(text_to_speak.encode("utf-8"))

--- a/config_default.py
+++ b/config_default.py
@@ -62,7 +62,9 @@ TRANSCRIPTION_API = "openai" # this will use the hosted openai api
 ### TTS SETTINGS ###
 TTS_ENGINE="openai" # 'piper' or 'openai' or 'mac'(mac is only for macos)
 
-PIPER_VOICE = "default_female_voice"
+PIPER_VOICE = "default_female_voice" # You can add more voices to the piper_tts/voices folder
+PIPER_VOICE_INDEX = 0 # For multi-voice models, select the index of the voice you want to use
+
 OPENAI_VOICE = "nova"
 
 ### PROMPTS ###


### PR DESCRIPTION
Some models of Piper have multiple voices built into them, so to support that I added a PIPER_VOICE_INDEX integer option to config.

The option defaults to 0. If a non-zero value is used for a single-voice model, it uses the only voice that exists anyway.