### PR TITLE
add keep-alive support for ollama

### DIFF
--- a/config_default.py
+++ b/config_default.py
@@ -13,6 +13,7 @@ USE_GPU = False  # Set to True to use GPU acceleration. Refer to the README for 
 # COMPLETIONS_API = "ollama"
 # COMPLETION_MODEL = "llama3"
 # OLLAMA_API_BASE_URL = "http://localhost:11434" #This should be the defualt
+# OLLAMA_KEEP_ALIVE = "5m" # The duration that models stay loaded in memory (default "5m"). Set to "-1" to keep models loaded indefinitely
 
 ## LM Studio COMPLETIONS API EXAMPLE ##
 # COMPLETIONS_API = "lm_studio" 

--- a/llm_apis/ollama_client.py
+++ b/llm_apis/ollama_client.py
@@ -26,7 +26,6 @@ class OllamaClient:
         Args:
             messages (list): List of messages used as context or prompt.
             model (str): Model identifier for text generation.
-            keep_alive (number/str): The duration that models stay loaded in memory (default "5m"). Set to "-1" to keep models loaded indefinitely
             **kwargs: Additional keyword arguments for the API request.
 
         Yields:

--- a/llm_apis/ollama_client.py
+++ b/llm_apis/ollama_client.py
@@ -1,6 +1,8 @@
 import requests
 import json
 import os
+from config_loader import config
+
 
 class OllamaClient:
     """Client for interacting with the Ollama API for streaming text completions."""
@@ -24,6 +26,7 @@ class OllamaClient:
         Args:
             messages (list): List of messages used as context or prompt.
             model (str): Model identifier for text generation.
+            keep_alive (number/str): The duration that models stay loaded in memory (default "5m"). Set to "-1" to keep models loaded indefinitely
             **kwargs: Additional keyword arguments for the API request.
 
         Yields:
@@ -34,6 +37,7 @@ class OllamaClient:
             "model": model,
             "messages": messages,
             "stream": True,
+            "keep_alive": config.OLLAMA_KEEP_ALIVE,
             **kwargs
         }
         json_data = json.dumps(data)


### PR DESCRIPTION
Add keep-alive support for Ollama. This can be useful for creating headless personal assistant where a constant memory usage is not a issue.