### PR TITLE
Add PIPER_VOICE_LENGTH to support adjusting the speed of Piper's speech

### DIFF
--- a/TTS_apis/piper_tts_client.py
+++ b/TTS_apis/piper_tts_client.py
@@ -64,7 +64,8 @@ class PiperTTSClient:
                 "-m", model_path,
                 "-c", json_path,
                 "-f", output_file,
-                "-s", str(config.PIPER_VOICE_INDEX)
+                "-s", str(config.PIPER_VOICE_INDEX),
+                "--length_scale", str(config.PIPER_VOICE_LENGTH)
             ]
             process = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=(None if self.verbose else subprocess.DEVNULL), stderr=subprocess.STDOUT)
             process.communicate(text_to_speak.encode("utf-8"))

--- a/config_default.py
+++ b/config_default.py
@@ -68,6 +68,7 @@ TTS_ENGINE="openai" # 'piper' or 'openai' or 'mac'(mac is only for macos)
 
 PIPER_VOICE = "default_female_voice" # You can add more voices to the piper_tts/voices folder
 PIPER_VOICE_INDEX = 0 # For multi-voice models, select the index of the voice you want to use
+PIPER_VOICE_LENGTH = 1.0 # Phoneme length scale: Lower values result in faster speech
 
 OPENAI_VOICE = "nova"
 


### PR DESCRIPTION
Piper supports controlling the rate of its speech with `--length_scale` (which scales the length of phonemes), where a lower value results in faster speech, and vice versa.

I've added that as a config.py option.