### PR TITLE
Add ALWAYS_INCLUDE_CLIPBOARD option

### DIFF
--- a/config_default.py
+++ b/config_default.py
@@ -84,6 +84,7 @@ RECORD_HOTKEY = 'alt+ctrl+r' # Press to start, press again to stop, or hold and 
 
 RECORD_HOTKEY_DELAY = 0.2 # Seconds to wait for RECORD_HOTKEY double tap before starting recording
 SUPPRESS_NATIVE_HOTKEYS = True # Suppress the native system functionality of the defined hotkeys above (Windows only)
+ALWAYS_INCLUDE_CLIPBOARD = False # Always include the clipboard content without having to double tap the record hotkey
 
 
 ### MISC ###

--- a/main.py
+++ b/main.py
@@ -218,11 +218,15 @@ class AlwaysReddy:
         within_delay = time.time() - self.last_press_time < config.RECORD_HOTKEY_DELAY
         if is_pressed:
             self.last_press_time = time.time()
-            if self.recorder.recording and within_delay:
+
+            if config.ALWAYS_INCLUDE_CLIPBOARD:
+                self.clipboard_text = read_clipboard()
+            elif self.recorder.recording and within_delay:
                 self.clipboard_text = read_clipboard()
                 if self.verbose:
                     print("Using clipboard...")
                 return
+
             self.start_main_thread() # start recording
         else:
             if self.recorder.recording and not within_delay:

--- a/main.py
+++ b/main.py
@@ -142,7 +142,7 @@ class AlwaysReddy:
 
             # If the user wants to use the clipboard text, append it to the message
             if self.clipboard_text:
-                self.messages.append({"role": "user", "content": transcript + f"\n\nTHE USER HAS THIS TEXT COPIED TO THEIR CLIPBOARD:\n```{self.clipboard_text}```"})
+                self.messages.append({"role": "user", "content": transcript + f"\n\nCLIPBOARD CONTENT (ignore if user doesn't mention it):\n```{self.clipboard_text}```"})
                 self.clipboard_text = None
                 print("\nUsing the text in your clipboard...")
             else:


### PR DESCRIPTION
For those who might want it, I added a bool option for always including the clipboard content (defaults to False).

To reduce the risk of the AI chattering about the clipboard content when the user asks about something else, I also edited the passed-along text to include `(ignore if user doesn't mention it)`, which makes a clear improvement for Llama 3 8B.