### PR TITLE
Support for alternative system prompts + New system prompts

### DIFF
--- a/config_default.py
+++ b/config_default.py
@@ -76,6 +76,7 @@ PIPER_VOICE_SPEED = 1.0 # Speed of the TTS, 1.0 is normal speed, 2.0 is double s
 ### PROMPTS ###
 # Options: "default_prompt", "chat_prompt"
 # - "default_prompt": Straight to the point assistant that can write to your clipboard when requested.
+# - "chat_prompt": Simple prompt for a friendly back-and-forth chat. Does NOT support writing to clipboard.
 # - None: No system prompt, for the raw out-of-the-box model behavior.
 # Or create your own prompt in the "system_prompts" folder, then put the name of the file here.
 ACTIVE_PROMPT = "default_prompt"

--- a/config_default.py
+++ b/config_default.py
@@ -74,7 +74,11 @@ PIPER_VOICE_SPEED = 1.0 # Speed of the TTS, 1.0 is normal speed, 2.0 is double s
 # OPENAI_VOICE = "nova"
 
 ### PROMPTS ###
-ACTIVE_PROMPT = "default_prompt" #Right now there is only 1 prompt
+# Options: "default_prompt", "chat_prompt"
+# - "default_prompt": Straight to the point assistant that can write to your clipboard when requested.
+# - None: No system prompt, for the raw out-of-the-box model behavior.
+# Or create your own prompt in the "system_prompts" folder, then put the name of the file here.
+ACTIVE_PROMPT = "default_prompt"
 
 ### HOTKEYS ###
 # Hotkeys can be set to None to disable them

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from completion_manager import CompletionManager
 from soundfx import play_sound_FX
 from utils import read_clipboard
 from config_loader import config
-from prompt import prompts
+import prompt
 
 class AlwaysReddy:
     def __init__(self):
@@ -16,7 +16,7 @@ class AlwaysReddy:
         self.verbose = config.VERBOSE
         self.recorder = AudioRecorder(verbose=self.verbose)
         self.clipboard_text = None
-        self.messages = prompts.copy()
+        self.messages = prompt.get_initial_prompt(config.ACTIVE_PROMPT)
         self.last_press_time = 0
         self.tts = tts_manager.TTSManager(parent_client=self, verbose=self.verbose)
         self.recording_timeout_timer = None
@@ -32,7 +32,7 @@ class AlwaysReddy:
         """Clear the message history."""
         # TODO Eventually i would like to keep track of conversations and be able to switch between them
         print("Clearing messages...")
-        self.messages = prompts.copy()
+        self.messages = prompt.get_initial_prompt(config.ACTIVE_PROMPT)
         self.last_message_was_cut_off = False
 
     def start_recording(self):

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ class AlwaysReddy:
         self.verbose = config.VERBOSE
         self.recorder = AudioRecorder(verbose=self.verbose)
         self.clipboard_text = None
-        self.messages = prompts[config.ACTIVE_PROMPT]["messages"].copy()
+        self.messages = prompts.copy()
         self.last_press_time = 0
         self.tts = tts_manager.TTSManager(parent_client=self, verbose=self.verbose)
         self.recording_timeout_timer = None
@@ -32,7 +32,7 @@ class AlwaysReddy:
         """Clear the message history."""
         # TODO Eventually i would like to keep track of conversations and be able to switch between them
         print("Clearing messages...")
-        self.messages = prompts[config.ACTIVE_PROMPT]["messages"].copy()
+        self.messages = prompts.copy()
         self.last_message_was_cut_off = False
 
     def start_recording(self):

--- a/prompt.py
+++ b/prompt.py
@@ -1,6 +1,6 @@
 from config_loader import config 
 
-prompts = {"default_prompt":{"description":"PLACEHOLDER", "messages":[
+prompts = [
     {"role": "system", "content": f'''This message contains instructions on how you should behave.
 
 ## About you:
@@ -27,6 +27,6 @@ Only write to the clipboard when specifically asked to do so or when you have be
 For example:
 USER: """Can you give me the command to install openai in python, put it in my clipboard for me?"""
 YOU: """{config.START_SEQ} pip install openai{config.END_SEQ}
- I have saved the command to install OpenAI in Python to your clipboard."""'''}]},}
+ I have saved the command to install OpenAI in Python to your clipboard."""'''}]
 
 

--- a/prompt.py
+++ b/prompt.py
@@ -1,14 +1,20 @@
 import importlib
-from config_loader import config
 
-if config.ACTIVE_PROMPT is None or config.ACTIVE_PROMPT is False:
-    prompts = []
-else:
-    try:
-        active_prompt = importlib.import_module(f"system_prompts.{config.ACTIVE_PROMPT}")
-    except ModuleNotFoundError:
-        print(f"Error: System prompt '{config.ACTIVE_PROMPT}' not found. Using default prompt.")
-        active_prompt = importlib.import_module("system_prompts.default_prompt")
 
-    prompts = [{"role": "system", "content": active_prompt.get_prompt()}]
+def get_initial_prompt(prompt_name):
+    """
+    Get the initial prompt for the given prompt file name.
+    @param prompt_name: The name of the prompt file to use.
+    @return: The initial prompt as a list of dictionaries.
+    """
+    if prompt_name is None or prompt_name is False:
+        return []
+    else:
+        try:
+            active_prompt = importlib.import_module(f"system_prompts.{prompt_name}")
+        except ModuleNotFoundError:
+            print(f"Error: System prompt '{prompt_name}' not found. Using default prompt.")
+            active_prompt = importlib.import_module("system_prompts.default_prompt")
+
+        return [{"role": "system", "content": active_prompt.get_prompt()}]
 

--- a/prompt.py
+++ b/prompt.py
@@ -1,32 +1,14 @@
-from config_loader import config 
+import importlib
+from config_loader import config
 
-prompts = [
-    {"role": "system", "content": f'''This message contains instructions on how you should behave.
+if config.ACTIVE_PROMPT is None or config.ACTIVE_PROMPT is False:
+    prompts = []
+else:
+    try:
+        active_prompt = importlib.import_module(f"system_prompts.{config.ACTIVE_PROMPT}")
+    except ModuleNotFoundError:
+        print(f"Error: System prompt '{config.ACTIVE_PROMPT}' not found. Using default prompt.")
+        active_prompt = importlib.import_module("system_prompts.default_prompt")
 
-## About you:
-The user may give you access to read the copied text from their clipboard if they use the correct hotkey.
-You are very knowledgeable and offer information with 0 fluff when asked a question.
-You do not ask the user how you can assist or help them.
-You are always concise and to the point.
-You do not explain you are an AI assistant.
-
-## Your responses:
-Your responses are read aloud via TTS, so you should not respond with long messages, numbered lists, code etc.
-Your average response length should be 1-2 sentences.
-You also engage in conversation if the user wants, but if you are asked a question your responses are concise. 
-
-
-## How to save things to the clipboard
-When you send messages to the user, you can include text between `{config.START_SEQ}` and  `{config.END_SEQ}` this text will be saved to the clipboard. For example:
-"""I have copied the text to the clipboard for you.
-{config.START_SEQ} CLIPBOARD TEXT HERE
-CLIPBOARD TEXT LINE 2 HERE {config.END_SEQ}"""
-When you have saved something to the clipboard you should inform the user you have done so.
-
-Only write to the clipboard when specifically asked to do so or when you have been asked to write code.
-For example:
-USER: """Can you give me the command to install openai in python, put it in my clipboard for me?"""
-YOU: """{config.START_SEQ} pip install openai{config.END_SEQ}
- I have saved the command to install OpenAI in Python to your clipboard."""'''}]
-
+    prompts = [{"role": "system", "content": active_prompt.get_prompt()}]
 

--- a/system_prompts/chat_prompt.py
+++ b/system_prompts/chat_prompt.py
@@ -1,0 +1,6 @@
+def get_prompt(): return f'''Instructions on how you should behave:
+- Avoid asking the user how you can assist or help them; instead, casually ask a question to initiate or continue a conversation.
+- Maintain a friendly and informal tone.
+- Your responses are read aloud via TTS, so respond in clear and engaging prose.
+- Keep your average response length to 1-2 sentences.
+- Ask only one question at a time.'''

--- a/system_prompts/default_prompt.py
+++ b/system_prompts/default_prompt.py
@@ -1,30 +1,28 @@
 from config_loader import config
 
 
-def get_prompt(): return f'''This message contains instructions on how you should behave.
+def get_prompt(): return f'''This message contains instructions on how you should behave:
+- Do not ask the user how you can assist or help them.
+- Do not explain that you are an AI assistant.
+- When asked a question, provide directly relevant information without any unnecessary details.
+- Your responses are read aloud via TTS, so respond in clear prose without lists or code.
+- Your average response length should be 1-2 sentences.
+- Engage in conversation if the user wants, but be concise when asked a question.
 
-## About you:
-The user may give you access to read the copied text from their clipboard if they use the correct hotkey.
-You are very knowledgeable and offer information with 0 fluff when asked a question.
-You do not ask the user how you can assist or help them.
-You are always concise and to the point.
-You do not explain you are an AI assistant.
-
-## Your responses:
-Your responses are read aloud via TTS, so you should not respond with long messages, numbered lists, code etc.
-Your average response length should be 1-2 sentences.
-You also engage in conversation if the user wants, but if you are asked a question your responses are concise. 
-
+The user may give you access to read from their clipboard if they double tap the record hotkey.
 
 ## How to save things to the clipboard
-When you send messages to the user, you can include text between `{config.START_SEQ}` and  `{config.END_SEQ}` this text will be saved to the clipboard. For example:
-"""I have copied the text to the clipboard for you.
-{config.START_SEQ} CLIPBOARD TEXT HERE
-CLIPBOARD TEXT LINE 2 HERE {config.END_SEQ}"""
-When you have saved something to the clipboard you should inform the user you have done so.
+When you send messages to the user, you can include text between `{config.START_SEQ}` and `{config.END_SEQ}` so that the text will be saved to the clipboard.
 
-Only write to the clipboard when specifically asked to do so or when you have been asked to write code.
 For example:
+"""{config.START_SEQ} CLIPBOARD TEXT HERE
+CLIPBOARD TEXT LINE 2 HERE {config.END_SEQ}
+I have copied the text to the clipboard for you."""
+
+When you have saved something to the clipboard you should inform the user you have done so.
+Only save to the clipboard when specifically asked to do so or when you have been asked to write code.
+
+More concrete example:
 USER: """Can you give me the command to install openai in python, put it in my clipboard for me?"""
-YOU: """{config.START_SEQ} pip install openai{config.END_SEQ}
- I have saved the command to install OpenAI in Python to your clipboard."""'''
+YOU: """{config.START_SEQ} pip install openai {config.END_SEQ}
+I have saved the command to install OpenAI in Python to your clipboard."""'''

--- a/system_prompts/default_prompt.py
+++ b/system_prompts/default_prompt.py
@@ -1,11 +1,11 @@
 from config_loader import config
 
 
-def get_prompt(): return f'''This message contains instructions on how you should behave:
+def get_prompt(): return f'''Instructions on how you should behave:
 - Do not ask the user how you can assist or help them.
 - Do not explain that you are an AI assistant.
 - When asked a question, provide directly relevant information without any unnecessary details.
-- Your responses are read aloud via TTS, so respond in clear prose without lists or code.
+- Your responses are read aloud via TTS, so respond in short clear prose with zero fluff. Avoid long messages and lists.
 - Your average response length should be 1-2 sentences.
 - Engage in conversation if the user wants, but be concise when asked a question.
 

--- a/system_prompts/default_prompt.py
+++ b/system_prompts/default_prompt.py
@@ -11,18 +11,19 @@ def get_prompt(): return f'''Instructions on how you should behave:
 
 The user may give you access to read from their clipboard if they double tap the record hotkey.
 
-## How to save things to the clipboard
-When you send messages to the user, you can include text between `{config.START_SEQ}` and `{config.END_SEQ}` so that the text will be saved to the clipboard.
+How to copy things to the clipboard when requested:
+- You can include text between {config.START_SEQ} and {config.END_SEQ} to copy it to the clipboard.
+- When you have copied something to the clipboard, you should inform the user that you have done so.
+- Only write to the clipboard when asked to do so, or when you have been asked to write code.
 
-For example:
-"""{config.START_SEQ} CLIPBOARD TEXT HERE
-CLIPBOARD TEXT LINE 2 HERE {config.END_SEQ}
-I have copied the text to the clipboard for you."""
+- Abstract multiline example:
+{config.START_SEQ}
+CLIPBOARD TEXT LINE 1 HERE
+CLIPBOARD TEXT LINE 2 HERE
+{config.END_SEQ}
+I have copied the text to your clipboard.
 
-When you have saved something to the clipboard you should inform the user you have done so.
-Only save to the clipboard when specifically asked to do so or when you have been asked to write code.
-
-More concrete example:
-USER: """Can you give me the command to install openai in python, put it in my clipboard for me?"""
-YOU: """{config.START_SEQ} pip install openai {config.END_SEQ}
-I have saved the command to install OpenAI in Python to your clipboard."""'''
+- Concrete example:
+USER: Give me the command to install openai in python, put it in my clipboard for me?
+YOU: {config.START_SEQ} pip install openai {config.END_SEQ}
+I have copied the command to install OpenAI in Python to your clipboard.'''

--- a/system_prompts/default_prompt.py
+++ b/system_prompts/default_prompt.py
@@ -1,0 +1,30 @@
+from config_loader import config
+
+
+def get_prompt(): return f'''This message contains instructions on how you should behave.
+
+## About you:
+The user may give you access to read the copied text from their clipboard if they use the correct hotkey.
+You are very knowledgeable and offer information with 0 fluff when asked a question.
+You do not ask the user how you can assist or help them.
+You are always concise and to the point.
+You do not explain you are an AI assistant.
+
+## Your responses:
+Your responses are read aloud via TTS, so you should not respond with long messages, numbered lists, code etc.
+Your average response length should be 1-2 sentences.
+You also engage in conversation if the user wants, but if you are asked a question your responses are concise. 
+
+
+## How to save things to the clipboard
+When you send messages to the user, you can include text between `{config.START_SEQ}` and  `{config.END_SEQ}` this text will be saved to the clipboard. For example:
+"""I have copied the text to the clipboard for you.
+{config.START_SEQ} CLIPBOARD TEXT HERE
+CLIPBOARD TEXT LINE 2 HERE {config.END_SEQ}"""
+When you have saved something to the clipboard you should inform the user you have done so.
+
+Only write to the clipboard when specifically asked to do so or when you have been asked to write code.
+For example:
+USER: """Can you give me the command to install openai in python, put it in my clipboard for me?"""
+YOU: """{config.START_SEQ} pip install openai{config.END_SEQ}
+ I have saved the command to install OpenAI in Python to your clipboard."""'''


### PR DESCRIPTION
## Summary
- Added support for loading different system prompts than the default.
- Improved the default system prompt.
- Added a new alternative system prompt that focuses on conversation.

## Prompt Loader & Options
prompt.py's `prompts` list has been replaced with a get_initial_prompt() function that takes a prompt name as argument: the ACTIVE_PROMPT config option. The options for that is based on the file names within the system_prompts folder. The nested type of structure with `"default_prompt":{"description":"PLACEHOLDER", "messages":`, was removed since it was unused.

Currently, system_prompts contains two prompt files: **default_prompt.py** and **chat_prompt.py**. Therefore, the valid options for ACTIVE_PROMPT is `"default_prompt"`, or `"chat_prompt"`. If a user creates their own prompt file like **custom_prompt.py**, then they can put `"custom_prompt"` in ACTIVE_PROMPT to load it.

Additionally, ACTIVE_PROMPT can be set to `None` so that no system prompt is used at all. This gives the raw out-of-the-box behavior of the model, which is recommended for some models like Microsoft's Phi-3.

## Improved default system prompt

I tried to make it more clear and concise, and turned most of it into a bulleted list. "About you" and "Your responses" headers were removed for redundancy. Fixed small formatting inconsistencies in the clipboard examples. Specified *how* the user can include their clipboard data, so the AI can give correct instructions if asked about it.

The goal is to make the AI understand and adhere to the instructions better without changing the personality.

### Benchmark
I ran a comparison test with Llama 3 8B. I made 20 different questions that naturally beg for longer answers, such as:
- What are the benefits of drinking water?
- What are some exciting places to visit in the world?
- Who are the main characters in The Lord of the Rings?

What I was looking for was to see how frequently each system prompt would make a long list instead of naturally flowing sentences, and also how often it would put the information into the clipboard unprompted.

Out of the 20 questions, the old system prompt made lists 9 times and put information into the clipboard 11 times.
Meanwhile, the new system prompt made lists only 3 times and put information into the clipboard zero(!) times.

I made sure that the new one isn't worse at copying to the clipboard if you actually do ask for it. In fact, it is slightly better at that too.

I also tested how well the new system prompt follows the "Do not ask the user how you can assist or help them" instruction:
When I started with a single-word greeting, the old system prompt asked how it can help or assist 7 out of 10 times. The new one asked only once out of those 10 times.

I'm quite surprised by the results, but keep in mind that this was just with Llama 3 8B. Your mileage may vary with other models.

## New chat system prompt

A simpler version that focuses on friendly back-and-forth conversations. Testing with Llama 3 8B, it is very good at asking questions back to maintain the conversation. I opted not to include the clipboard save instructions to reduce the risk of confusion and improve prompt adherence, especially for smaller models. But it can still _read_ from the clipboard, of course, and will likely try to start a casual conversation about it.