### PR TITLE
Dynamic system prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ class AlwaysReddy:
         self.verbose = config.VERBOSE
         self.recorder = AudioRecorder(verbose=self.verbose)
         self.clipboard_text = None
-        self.messages = prompt.get_initial_prompt(config.ACTIVE_PROMPT)
+        self.messages = prompt.build_initial_messages(config.ACTIVE_PROMPT)
         self.last_press_time = 0
         self.tts = tts_manager.TTSManager(parent_client=self, verbose=self.verbose)
         self.recording_timeout_timer = None
@@ -32,7 +32,7 @@ class AlwaysReddy:
         """Clear the message history."""
         # TODO Eventually i would like to keep track of conversations and be able to switch between them
         print("Clearing messages...")
-        self.messages = prompt.get_initial_prompt(config.ACTIVE_PROMPT)
+        self.messages = prompt.build_initial_messages(config.ACTIVE_PROMPT)
         self.last_message_was_cut_off = False
 
     def start_recording(self):
@@ -136,6 +136,10 @@ class AlwaysReddy:
             transcript (str): The transcribed text from the audio recording.
         """
         try:
+            # Refresh system prompt. For system prompts that contain variables like date and time
+            if len(self.messages) > 0 and self.messages[0]["role"] == "system":
+                self.messages[0]["content"] = prompt.get_system_prompt_message(config.ACTIVE_PROMPT)
+
             # If the user has cut off the assistant's last message, add a message to indicate this
             if self.last_message_was_cut_off:
                 transcript = "--> USER CUT THE ASSISTANTS LAST MESSAGE SHORT <--\n" + transcript

--- a/prompt.py
+++ b/prompt.py
@@ -1,7 +1,7 @@
 import importlib
 
 
-def get_initial_prompt(prompt_name):
+def build_initial_messages(prompt_name):
     """
     Get the initial prompt for the given prompt file name.
     @param prompt_name: The name of the prompt file to use.
@@ -10,11 +10,22 @@ def get_initial_prompt(prompt_name):
     if prompt_name is None or prompt_name is False:
         return []
     else:
+        return [{"role": "system", "content": get_system_prompt_message(prompt_name)}]
+
+
+def get_system_prompt_message(prompt_name):
+    """
+    Get the system prompt message for the given prompt file name.
+    @param prompt_name: The name of the prompt file to use.
+    @return: The system prompt message as a string.
+    """
+    if prompt_name is None or prompt_name is False:
+        return ""
+    else:
         try:
-            active_prompt = importlib.import_module(f"system_prompts.{prompt_name}")
+            system_prompt = importlib.import_module(f"system_prompts.{prompt_name}")
         except ModuleNotFoundError:
             print(f"Error: System prompt '{prompt_name}' not found. Using default prompt.")
-            active_prompt = importlib.import_module("system_prompts.default_prompt")
+            system_prompt = importlib.import_module("system_prompts.default_prompt")
 
-        return [{"role": "system", "content": active_prompt.get_prompt()}]
-
+        return system_prompt.get_prompt()

--- a/system_prompts/chat_prompt.py
+++ b/system_prompts/chat_prompt.py
@@ -1,6 +1,11 @@
+from datetime import datetime
+
 def get_prompt(): return f'''Instructions on how you should behave:
 - Avoid asking the user how you can assist or help them; instead, casually ask a question to initiate or continue a conversation.
 - Maintain a friendly and informal tone.
 - Your responses are read aloud via TTS, so respond in clear and engaging prose.
 - Keep your average response length to 1-2 sentences.
-- Ask only one question at a time.'''
+- Ask only one question at a time.
+
+Current date: {datetime.now().strftime("%Y-%m-%d (%A)")}
+Current time: {datetime.now().strftime("%H:%M")}'''

--- a/system_prompts/default_prompt.py
+++ b/system_prompts/default_prompt.py
@@ -1,4 +1,5 @@
 from config_loader import config
+from datetime import datetime
 
 
 def get_prompt(): return f'''Instructions on how you should behave:
@@ -8,6 +9,9 @@ def get_prompt(): return f'''Instructions on how you should behave:
 - Your responses are read aloud via TTS, so respond in short clear prose with zero fluff. Avoid long messages and lists.
 - Your average response length should be 1-2 sentences.
 - Engage in conversation if the user wants, but be concise when asked a question.
+
+Current date: {datetime.now().strftime("%Y-%m-%d (%A)")}
+Current time: {datetime.now().strftime("%H:%M")}
 
 The user may give you access to read from their clipboard if they double tap the record hotkey.
 


### PR DESCRIPTION
Update the system prompt before generating responses, so that if a variable (such as date and time) is used in the system prompt, it will be kept up to date.

`prompt.get_initial_prompt()` was also renamed to `prompt.build_initial_messages()` to more accurately reflect its purpose. 

`prompt.get_system_prompt_message()` was added that only returns the system prompt message string, which `prompt.build_initial_messages()` now uses.

`prompt.get_system_prompt_message()` is also used directly in `handle_response()` to refresh the first entry content of `self.messages` instead of rebuilding `self.messages` entirely.

Additionally, both built-in system prompts (**default_prompt** and **chat_prompt**) was updated to include the current date and time. I benchmarked it with Llama 3.1 8B, and it does not negatively affect system prompt adherence.