### PR TITLE
Support config.py containing options that config_default.py does not

### DIFF
--- a/config_default.py
+++ b/config_default.py
@@ -20,7 +20,7 @@ TRANSCRIBE_RECORDING = "ctrl+alt+t"
 # COMPLETIONS_API = "ollama"
 # COMPLETION_MODEL = "llama3"
 # OLLAMA_API_BASE_URL = "http://localhost:11434" #This should be the defualt
-OLLAMA_KEEP_ALIVE = "-1s" # The duration that models stay loaded in memory examples: "20m", "24h". Set to "-1s" to keep models loaded indefinitely
+# OLLAMA_KEEP_ALIVE = "-1s" # The duration that models stay loaded in memory examples: "20m", "24h". Set to "-1s" to keep models loaded indefinitely
 
 ## LM Studio COMPLETIONS API EXAMPLE ##
 # COMPLETIONS_API = "lm_studio" 

--- a/config_loader.py
+++ b/config_loader.py
@@ -50,6 +50,10 @@ class ConfigLoader:
             if not key.startswith('__'):
                 setattr(self, key, getattr(user_config, key, value))
 
+        for key, value in user_config.__dict__.items():
+            if not key.startswith('__') and key not in default_config.__dict__:
+                setattr(self, key, value)
+
     def _import_config(self, config_path):
         spec = importlib.util.spec_from_file_location("config", config_path)
         config = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
Proper fix for https://github.com/ILikeAI/AlwaysReddy/issues/74.

In other words, we can have options like OLLAMA_KEEP_ALIVE commented out in the default_config.py without that breaking anything as long as the user correctly uncomments it in his config.py when using Ollama.