### PR TITLE
Support for all hotkeys to be None, plus minor clean-up

### DIFF
--- a/actions/always_reddy_voice_assistant/main.py
+++ b/actions/always_reddy_voice_assistant/main.py
@@ -1,6 +1,5 @@
 import time
 from config_loader import config
-import prompt
 from actions.base_action import BaseAction
 from utils import to_clipboard
 import prompt
@@ -11,13 +10,12 @@ class AlwaysReddyVoiceAssistant(BaseAction):
         self.last_message_was_cut_off = False
         
         if config.RECORD_HOTKEY:
-            # HOTKEY CONFIGURATION
             self.AR.add_action_hotkey(config.RECORD_HOTKEY, 
                                 pressed=self.handle_default_assistant_response,
                                 held_release=self.handle_default_assistant_response,
                                 double_tap=self.AR.save_clipboard_text)
             
-            print(f"'{config.RECORD_HOTKEY}': Start/stop talking to voice assistant (press to toggle on and off or hold-release)")
+            print(f"'{config.RECORD_HOTKEY}': Start/stop talking to voice assistant (press to toggle on and off, or hold and release)")
             if "+" in config.RECORD_HOTKEY:
                 hotkey_start, hotkey_end = config.RECORD_HOTKEY.rsplit("+", 1)
                 print(f"\tHold down '{hotkey_start}' and double tap '{hotkey_end}' to send clipboard content to AlwaysReddy")

--- a/actions/always_reddy_voice_assistant/main.py
+++ b/actions/always_reddy_voice_assistant/main.py
@@ -12,7 +12,6 @@ class AlwaysReddyVoiceAssistant(BaseAction):
         
         if config.RECORD_HOTKEY:
             # HOTKEY CONFIGURATION
-            print("Voice assistant hotkeys:")  
             self.AR.add_action_hotkey(config.RECORD_HOTKEY, 
                                 pressed=self.handle_default_assistant_response,
                                 held_release=self.handle_default_assistant_response,

--- a/actions/always_reddy_voice_assistant/main.py
+++ b/actions/always_reddy_voice_assistant/main.py
@@ -10,7 +10,7 @@ class AlwaysReddyVoiceAssistant(BaseAction):
     def setup(self):
         self.last_message_was_cut_off = False
         
-        if config.TRANSCRIBE_RECORDING:
+        if config.RECORD_HOTKEY:
             # HOTKEY CONFIGURATION
             print("Voice assistant hotkeys:")  
             self.AR.add_action_hotkey(config.RECORD_HOTKEY, 
@@ -24,10 +24,12 @@ class AlwaysReddyVoiceAssistant(BaseAction):
                 print(f"\tHold down '{hotkey_start}' and double tap '{hotkey_end}' to send clipboard content to AlwaysReddy")
             else:
                 print(f"\tDouble tap '{config.RECORD_HOTKEY}' to send clipboard content to AlwaysReddy")
-            # new chat hotkey
+
+        if config.NEW_CHAT_HOTKEY:
             self.AR.add_action_hotkey(config.NEW_CHAT_HOTKEY, pressed=self.new_chat)
-            self.messages = prompt.build_initial_messages(config.ACTIVE_PROMPT)
             print(f"'{config.NEW_CHAT_HOTKEY}': New chat for voice assistant")
+
+        self.messages = prompt.build_initial_messages(config.ACTIVE_PROMPT)
 
     def handle_default_assistant_response(self):
         """Handle the response from the transcription and generate a completion."""

--- a/actions/example_action/main.py
+++ b/actions/example_action/main.py
@@ -13,7 +13,7 @@ class ExampleAction(BaseAction):
     def transcription_action(self):
         """Handle the transcription process."""
         recording_filename = self.AR.toggle_recording(self.transcription_action)
-        if recording_filename:#If the recording has only just been started, recording_filename will be None
+        if recording_filename: # If the recording has only just been started, recording_filename will be None
             transcript = self.AR.transcription_manager.transcribe_audio(recording_filename)
             to_clipboard(transcript)
             print("Transcription copied to clipboard.")

--- a/actions/transcribe_and_paste/main.py
+++ b/actions/transcribe_and_paste/main.py
@@ -11,7 +11,7 @@ class TranscribeAndPaste(BaseAction):
             self.AR.add_action_hotkey(config.TRANSCRIBE_RECORDING, 
                                 pressed=self.transcription_action,
                                 held_release=self.transcription_action)
-            print(f"'{config.TRANSCRIBE_RECORDING}': Transcribe to clipboard (press to toggle on and off hold-release)")
+            print(f"'{config.TRANSCRIBE_RECORDING}': Transcribe to clipboard (press to toggle on and off, or hold and release)")
 
     def transcription_action(self):
         """Handle the transcription process."""

--- a/config_default.py
+++ b/config_default.py
@@ -5,6 +5,7 @@ USE_GPU = False  # Set to True to use GPU acceleration. Refer to the README for 
 
 ### HOTKEY BINDINGS ###
 # Hotkeys can be set to None to disable them
+# On Mac/Linux, a hotkey cannot overlap another (e.g. cmd+e and cmd+shift+e)
 CANCEL_HOTKEY = 'alt+ctrl+e'
 NEW_CHAT_HOTKEY = 'alt+ctrl+w'
 RECORD_HOTKEY = 'alt+ctrl+r' # Press to start, press again to stop, or hold and release. Double tap to include clipboard

--- a/main.py
+++ b/main.py
@@ -227,8 +227,10 @@ class AlwaysReddy:
         print("\nSystem actions:")
         
         # Add cancel_all as an action that doesn't run in the main thread
-        self.add_action_hotkey(config.CANCEL_HOTKEY, pressed=self.cancel_all, run_in_action_thread=False)
-        print(f"'{config.CANCEL_HOTKEY}': Cancel currently running action, recording, TTS or other")
+        if config.CANCEL_HOTKEY:
+            self.add_action_hotkey(config.CANCEL_HOTKEY, pressed=self.cancel_all, run_in_action_thread=False)
+            print(f"'{config.CANCEL_HOTKEY}': Cancel currently running action, recording, TTS or other")
+
         print("\nAlwaysReddy is reddy. Use any of the hotkeys above to get started.")
         try:
             self.input_handler.start(blocking=True)

--- a/main.py
+++ b/main.py
@@ -217,21 +217,22 @@ class AlwaysReddy:
                     module = importlib.import_module(module_name)
                     for name, obj in module.__dict__.items():
                         if isinstance(obj, type) and issubclass(obj, BaseAction) and obj is not BaseAction:
-                            print(f"\nInitializing action: {obj.__name__}")
-                            action_instance = obj(self)       
+                            if self.verbose:
+                                print(f"\nInitializing action: {obj.__name__}")
+                            obj(self)
 
     def run(self):
         """Run the AlwaysReddy instance, setting up hotkeys and entering the main loop."""
         print("\n\nSetting up AlwaysReddy...\n")
         self.discover_and_initialize_actions()
 
-        if any([config.CANCEL_HOTKEY]): # if not hotkey below is set, skip the "system actions" print
+        if self.verbose and any([config.CANCEL_HOTKEY]): # if not hotkey below is set, skip the "system actions" print
             print("\nSystem actions:")
 
-            # Add cancel_all as an action that doesn't run in the main thread
-            if config.CANCEL_HOTKEY:
-                self.add_action_hotkey(config.CANCEL_HOTKEY, pressed=self.cancel_all, run_in_action_thread=False)
-                print(f"'{config.CANCEL_HOTKEY}': Cancel currently running action, recording, TTS or other")
+        # Add cancel_all as an action that doesn't run in the main thread
+        if config.CANCEL_HOTKEY:
+            self.add_action_hotkey(config.CANCEL_HOTKEY, pressed=self.cancel_all, run_in_action_thread=False)
+            print(f"'{config.CANCEL_HOTKEY}': Cancel currently running action, recording, TTS, or other")
 
         print("\nAlwaysReddy is reddy. Use any of the hotkeys above to get started.")
         try:

--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ from config_loader import config
 import os
 import importlib
 from actions.base_action import BaseAction
-# Import actions
 
 class AlwaysReddy:
     def __init__(self):

--- a/main.py
+++ b/main.py
@@ -224,12 +224,14 @@ class AlwaysReddy:
         """Run the AlwaysReddy instance, setting up hotkeys and entering the main loop."""
         print("\n\nSetting up AlwaysReddy...\n")
         self.discover_and_initialize_actions()
-        print("\nSystem actions:")
-        
-        # Add cancel_all as an action that doesn't run in the main thread
-        if config.CANCEL_HOTKEY:
-            self.add_action_hotkey(config.CANCEL_HOTKEY, pressed=self.cancel_all, run_in_action_thread=False)
-            print(f"'{config.CANCEL_HOTKEY}': Cancel currently running action, recording, TTS or other")
+
+        if any([config.CANCEL_HOTKEY]): # if not hotkey below is set, skip the "system actions" print
+            print("\nSystem actions:")
+
+            # Add cancel_all as an action that doesn't run in the main thread
+            if config.CANCEL_HOTKEY:
+                self.add_action_hotkey(config.CANCEL_HOTKEY, pressed=self.cancel_all, run_in_action_thread=False)
+                print(f"'{config.CANCEL_HOTKEY}': Cancel currently running action, recording, TTS or other")
 
         print("\nAlwaysReddy is reddy. Use any of the hotkeys above to get started.")
         try:


### PR DESCRIPTION
Unbound hotkeys
---
Before the actions system, all hotkeys could be set to None to unbind them. But now, setting some of them to None cause exceptions. This fixes that.



Verbosity
---
More initial prints are now hidden with `verbose = False`, making the program initialization more succinct. Besides debugging, there is no reason to categorize the bindings by action when there are only five in total.

Let's compare:

##### Before:
```
Setting up AlwaysReddy...


Initializing action: AlwaysReddyVoiceAssistant
Voice assistant hotkeys:
'alt+ctrl+r': Start/stop talking to voice assistant (press to toggle on and off or hold-release)
	Hold down 'alt+ctrl' and double tap 'r' to send clipboard content to AlwaysReddy
'alt+ctrl+w': New chat for voice assistant

Initializing action: ReadClipboard
'ctrl+alt+c': To read the text in your clipboard aloud

Initializing action: TranscribeAndPaste
'ctrl+alt+t': Transcribe to clipboard (press to toggle on and off hold-release)

System actions:
'alt+ctrl+e': Cancel currently running action, recording, TTS or other

AlwaysReddy is reddy. Use any of the hotkeys above to get started.
```

##### After:
```
Setting up AlwaysReddy...

'alt+ctrl+r': Start/stop talking to voice assistant (press to toggle on and off, or hold and release)
	Hold down 'alt+ctrl' and double tap 'r' to send clipboard content to AlwaysReddy
'alt+ctrl+w': New chat for voice assistant
'ctrl+alt+c': To read the text in your clipboard aloud
'ctrl+alt+t': Transcribe to clipboard (press to toggle on and off, or hold and release)
'alt+ctrl+e': Cancel currently running action, recording, TTS, or other

AlwaysReddy is reddy. Use any of the hotkeys above to get started.
```