### PR TITLE
Add LLM API params option to config

### DIFF
--- a/actions/always_reddy_voice_assistant/main.py
+++ b/actions/always_reddy_voice_assistant/main.py
@@ -58,7 +58,7 @@ class AlwaysReddyVoiceAssistant(BaseAction):
                 if self.AR.stop_action:
                     return
 
-                stream = self.AR.completion_client.get_completion_stream(self.messages, model=config.COMPLETION_MODEL)
+                stream = self.AR.completion_client.get_completion_stream(self.messages, config.COMPLETION_MODEL, **config.COMPLETION_PARAMS)
                 response = self.AR.completion_client.process_text_stream(stream,
                                                                          marker_tuples=[(config.CLIPBOARD_TEXT_START_SEQ, config.CLIPBOARD_TEXT_END_SEQ, to_clipboard)],
                                                                           sentence_callback=self.AR.tts.run_tts)#We pass in pairs of start and end sequences to the marker_tuples argument to indicate that the text between these sequences should be copied to the clipboard, then we pass the to_clipboard function as the callback to handle this action.

--- a/completion_manager.py
+++ b/completion_manager.py
@@ -92,7 +92,7 @@ class CompletionManager:
             return None
         
     def get_completion_stream(self, messages, model, **kwargs):
-        """Get completion from the selected AI client and stream sentences into the TTS client.
+        """Get completion stream from the selected AI client.
 
         Args:
             messages (list): List of messages.

--- a/config_default.py
+++ b/config_default.py
@@ -62,7 +62,7 @@ COMPLETION_MODEL = "gpt-4o"
 
 ### COMPLETIONS API PARAMETERS ###
 # Allows you to override the default parameters for the completions API
-# The available parameters depend on which completions API you are using
+# The available parameters depend on which completions API you are using, so should be looked up in the API documentation online
 COMPLETION_PARAMS = {"temperature": 0.7, "max_tokens": 2048}
 
 ### TRANSCRIPTION API SETTINGS ###

--- a/config_default.py
+++ b/config_default.py
@@ -60,13 +60,17 @@ COMPLETION_MODEL = "gpt-4o"
 # COMPLETIONS_API = "groq"
 # COMPLETION_MODEL = "llama3-70b-8192"
 
-### Transcription API Settings ###
+### COMPLETIONS API PARAMETERS ###
+# Allows you to override the default parameters for the completions API
+# The available parameters depend on which completions API you are using
+COMPLETION_PARAMS = {"temperature": 0.7, "max_tokens": 2048}
+
+### TRANSCRIPTION API SETTINGS ###
 
 ## Faster Whisper local transcription ###
 TRANSCRIPTION_API = "FasterWhisper" # this will use the local whisper model
 WHISPER_MODEL = "tiny.en" # If you prefer not to use english set it to "tiny", if the transcription quality is too low then set it to "base" but this will be a little slower
 BEAM_SIZE = 5
-
 
 ## Transformers Whisper local transcription ###
 # TRANSCRIPTION_API = "TransformersWhisper"

--- a/llm_apis/anthropic_client.py
+++ b/llm_apis/anthropic_client.py
@@ -7,14 +7,12 @@ class AnthropicClient:
         self.client = Anthropic(api_key=os.getenv('ANTHROPIC_API_KEY'))
         self.verbose = verbose
 
-    def stream_completion(self, messages, model, temperature=0.7, max_tokens=2048, **kwargs):
+    def stream_completion(self, messages, model, **kwargs):
         """Stream completion from the Anthropic API.
 
         Args:
             messages (list): List of messages.
             model (str): Model for completion.
-            temperature (float): Temperature for sampling.
-            max_tokens (int): Maximum number of tokens to generate.
             **kwargs: Additional keyword arguments.
 
         Yields:
@@ -32,8 +30,7 @@ class AnthropicClient:
             api_args = {
                 "model": model,
                 "messages": messages,
-                "temperature": temperature,
-                "max_tokens": max_tokens,
+                **kwargs
             }
             
             # Only include the system parameter if a system message is present

--- a/llm_apis/groq_client.py
+++ b/llm_apis/groq_client.py
@@ -13,7 +13,7 @@ class GroqClient:
         self.client = Groq(api_key=os.getenv('GROQ_API_KEY'))
         self.verbose = verbose
 
-    def stream_completion(self, messages, model='llama3-8b-8192', **kwargs):
+    def stream_completion(self, messages, model, **kwargs):
         """
         Get chat completions from the Groq API.
 

--- a/llm_apis/lm_studio_client.py
+++ b/llm_apis/lm_studio_client.py
@@ -6,14 +6,12 @@ class LM_StudioClient:
         self.client = OpenAI(base_url=base_url, api_key="not-needed")
         self.verbose = verbose
 
-    def stream_completion(self, messages, model, temperature=0.7, max_tokens=2048, **kwargs):
+    def stream_completion(self, messages, model, **kwargs):
         """Get completion from LM studio API.
 
         Args:
             messages (list): List of messages.
-            model (str): Model for completion, this for now is alway "local-model"
-            temperature (float): Temperature for sampling.
-            max_tokens (int): Maximum number of tokens to generate.
+            model (str): Model for completion, this for now is always "local-model"
             **kwargs: Additional keyword arguments.
 
         Yields:
@@ -23,8 +21,6 @@ class LM_StudioClient:
             stream = self.client.chat.completions.create(
                 model=model,
                 messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
                 stream=True,
                 **kwargs
             )

--- a/llm_apis/ollama_client.py
+++ b/llm_apis/ollama_client.py
@@ -37,7 +37,7 @@ class OllamaClient:
             "messages": messages,
             "stream": True,
             "keep_alive": config.OLLAMA_KEEP_ALIVE,
-            **kwargs
+            "options": kwargs,
         }
         json_data = json.dumps(data)
         headers = {'Authorization': f'Bearer {self.api_key}'} if self.api_key else {}

--- a/llm_apis/openai_client.py
+++ b/llm_apis/openai_client.py
@@ -7,14 +7,12 @@ class OpenAIClient:
         self.client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
         self.verbose = verbose
 
-    def stream_completion(self, messages, model, temperature=0.7, max_tokens=2048, **kwargs):
+    def stream_completion(self, messages, model, **kwargs):
         """Get completion from OpenAI API.
 
         Args:
             messages (list): List of messages.
             model (str): Model for completion.
-            temperature (float): Temperature for sampling.
-            max_tokens (int): Maximum number of tokens to generate.
             **kwargs: Additional keyword arguments.
 
         Yields:
@@ -24,13 +22,12 @@ class OpenAIClient:
             stream = self.client.chat.completions.create(
                 model=model,
                 messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                stream=True
+                stream=True,
+                **kwargs
             )
             for chunk in stream:
                 content = chunk.choices[0].delta.content
-                if content != None:
+                if content is not None:
                     yield content
         except Exception as e:
             if self.verbose:

--- a/llm_apis/openrouter_client.py
+++ b/llm_apis/openrouter_client.py
@@ -11,14 +11,12 @@ class OpenRouterClient:
         self.base_url = "https://openrouter.ai/api/v1/chat/completions"
         self.verbose = verbose
 
-    def stream_completion(self, messages, model, temperature=0.7, max_tokens=2048, **kwargs):
+    def stream_completion(self, messages, model, **kwargs):
         """Stream completion from the OpenRouter API.
 
         Args:
             messages (list): List of messages.
             model (str): Model for completion.
-            temperature (float): Temperature for sampling.
-            max_tokens (int): Maximum number of tokens to generate.
             **kwargs: Additional keyword arguments.
 
         Yields:
@@ -27,8 +25,6 @@ class OpenRouterClient:
         payload = {
             "model": model,
             "messages": messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
             **kwargs
         }
         headers = {

--- a/llm_apis/perplexity_client.py
+++ b/llm_apis/perplexity_client.py
@@ -11,14 +11,12 @@ class PerplexityClient:
         self.base_url = "https://api.perplexity.ai/chat/completions"
         self.verbose = verbose
 
-    def stream_completion(self, messages, model, temperature=0.7, max_tokens=2048, **kwargs):
+    def stream_completion(self, messages, model, **kwargs):
         """Stream completion from the Perplexity AI API.
 
         Args:
             messages (list): List of messages.
             model (str): Model for completion.
-            temperature (float): Temperature for sampling.
-            max_tokens (int): Maximum number of tokens to generate.
             **kwargs: Additional keyword arguments.
 
         Yields:
@@ -27,8 +25,6 @@ class PerplexityClient:
         payload = {
             "model": model,
             "messages": messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
             **kwargs
         }
         headers = {

--- a/llm_apis/tabbyapi_client.py
+++ b/llm_apis/tabbyapi_client.py
@@ -9,14 +9,12 @@ class TabbyApiClient:
         self.client = OpenAI(api_key=key if key != "" else None, base_url=config.TABBY_API_BASE_URL)
         self.verbose = verbose
 
-    def stream_completion(self, messages, model, temperature=0.7, max_tokens=2048, **kwargs):
+    def stream_completion(self, messages, model, **kwargs):
         """Get completion from TabbyAPI.
 
         Args:
             messages (list): List of messages.
             model (str): Model for completion.
-            temperature (float): Temperature for sampling.
-            max_tokens (int): Maximum number of tokens to generate.
             **kwargs: Additional keyword arguments.
 
         Yields:
@@ -26,13 +24,12 @@ class TabbyApiClient:
             stream = self.client.chat.completions.create(
                 model=model,
                 messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                stream=True
+                stream=True,
+                **kwargs
             )
             for chunk in stream:
                 content = chunk.choices[0].delta.content
-                if content != None:
+                if content is not None:
                     yield content
         except Exception as e:
             if self.verbose:

--- a/llm_apis/togetherai_client.py
+++ b/llm_apis/togetherai_client.py
@@ -11,14 +11,12 @@ class TogetherAIClient:
         )
         self.verbose = verbose
 
-    def stream_completion(self, messages, model, temperature=0.7, max_tokens=2048, **kwargs):
+    def stream_completion(self, messages, model, **kwargs):
         """Get completion from the TogetherAI API.
 
         Args:
             messages (list): List of messages.
             model (str): Model for completion.
-            temperature (float): Temperature for sampling.
-            max_tokens (int): Maximum number of tokens to generate.
             **kwargs: Additional keyword arguments.
 
         Yields:
@@ -28,9 +26,8 @@ class TogetherAIClient:
             stream = self.client.chat.completions.create(
                 model=model,
                 messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                stream=True
+                stream=True,
+                **kwargs
             )
             for chunk in stream:
                 content = chunk.choices[0].delta.content


### PR DESCRIPTION
This allows users to tweak the parameters like temperature, repeat penalty, etc., of all the clients from this new option:
```py
### COMPLETIONS API PARAMETERS ###
# Allows you to override the default parameters for the completions API
# The available parameters depend on which completions API you are using, so should be looked up in the API documentation online
COMPLETION_PARAMS = {"temperature": 0.7, "max_tokens": 2048}
```
The two default arguments there are the same that were hardcoded in all clients before except Ollama, which was using its own default temperature of 0.8 instead. I kept them so that most users shouldn't notice any difference in their assistant's behaviour.

It's worth noting that the different clients do not have identical sets of parameters. For example, most use "max_tokens" to define the maximum length of the response, but Ollama's equivalent of that is "num_predict". The user will have to look up a list of available parameters for their API of choice.

I have only tested that the params work on Ollama and TabbyAPI, since I only use local LLMs. But the client code change is simple and is practically doing the same thing as before, so there should be no issue. 🤞 