### PR TITLE
Support OLLAMA_KEEP_ALIVE without time suffix + Exception handling

### DIFF
--- a/config_default.py
+++ b/config_default.py
@@ -21,7 +21,7 @@ TRANSCRIBE_RECORDING = "ctrl+alt+t"
 # COMPLETIONS_API = "ollama"
 # COMPLETION_MODEL = "llama3"
 # OLLAMA_API_BASE_URL = "http://localhost:11434" #This should be the defualt
-# OLLAMA_KEEP_ALIVE = "-1s" # The duration that models stay loaded in memory examples: "20m", "24h". Set to "-1s" to keep models loaded indefinitely
+# OLLAMA_KEEP_ALIVE = "-1" # The duration that models stay loaded in memory. Examples: "20m", "24h". Set to "-1" to keep models loaded indefinitely
 
 ## LM Studio COMPLETIONS API EXAMPLE ##
 # COMPLETIONS_API = "lm_studio" 

--- a/llm_apis/ollama_client.py
+++ b/llm_apis/ollama_client.py
@@ -1,6 +1,7 @@
 import requests
 import json
 import os
+import re
 from config_loader import config
 
 
@@ -36,7 +37,7 @@ class OllamaClient:
             "model": model,
             "messages": messages,
             "stream": True,
-            "keep_alive": config.OLLAMA_KEEP_ALIVE,
+            "keep_alive": self.__fix_keep_alive(config.OLLAMA_KEEP_ALIVE),
             **kwargs
         }
         json_data = json.dumps(data)
@@ -60,3 +61,14 @@ class OllamaClient:
             else:
                 print(f"An error occurred streaming completion from Ollama API: {e}")
             raise RuntimeError(f"An error occurred streaming completion from Ollama API: {e}")
+
+    def __fix_keep_alive(self, keep_alive):
+        """ Attempts to fix the keep_alive value if it is not a valid string. Returns -1 as a fallback. """
+        try:
+            return int(keep_alive)
+        except ValueError:
+            pattern = r"^-?\d+[smh]$"
+            if re.match(pattern, keep_alive) is not None:
+                return keep_alive
+            print(f"Invalid OLLAMA_KEEP_ALIVE value: {keep_alive}. Must be a number followed by s, m, or h.")
+            return -1


### PR DESCRIPTION
This pull request does two things:
- Support OLLAMA_KEEP_ALIVE without s/m/h suffix, like "-1" for indefinite or "30" for thirty seconds. Just in case of user error.
- In case an invalid value is used, print a clear warning about it instead of the elusive "STATUS CODE 400" exception, and loads the model indefinitely as a fallback.