### PR TITLE
Modular System Prompt + Option to let assistant see current window title

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,17 @@ To use local TTS just open the config file and set `TTS_ENGINE="piper"`
 4. Edit your config.py file by setting the `ACTIVE_PROMPT` option to the name of your new prompt file (without the .py extension) as a string.
    - For example, if your new prompt file is *custom_prompt.py*, then set in config.py: `ACTIVE_PROMPT = "custom_prompt"`
 
+### System prompt modules
+An alternative way to customize the system prompt is to create a new "system prompt module". These modules, found in the *system_prompts\modules* directory, are additional instructions that can be appended to your base system prompt.
+
+For example, the default 'clipboard' module contains the instructions that gives the assistant the ability to copy generated text into your clipboard.
+
+#### How to make a custom system prompt module:
+1. Navigate to the *system_prompts\modules* directory.
+2. Make a copy of an existing module file.
+3. Open the copy in a text or code editor and edit the prompt inside the two `'''` as you like.
+4. Edit your config.py file by adding your module file name (without the .py extension) to the `ACTIVE_PROMPT_MODULES` list option.
+
 ## How to add AlwaysReddy to Startup List (Windows)
 To add AlwaysReddy to your startup list so it starts automatically on your computer startup, follow these steps:
 1. run `venv\Scripts\activate`

--- a/config_default.py
+++ b/config_default.py
@@ -87,12 +87,18 @@ PIPER_VOICE_SPEED = 1.0 # Speed of the TTS, 1.0 is normal speed, 2.0 is double s
 # OPENAI_VOICE = "nova"
 
 ### PROMPTS ###
-# Options: "default_prompt", "chat_prompt"
+# Options:
 # - "default_prompt": Straight to the point assistant that can write to your clipboard when requested.
 # - "chat_prompt": Simple prompt for a friendly back-and-forth chat. Does NOT support writing to clipboard.
 # - None: No system prompt, for the raw out-of-the-box model behavior.
 # Or create your own prompt in the "system_prompts" folder, then put the name of the file here.
 ACTIVE_PROMPT = "default_prompt"
+
+# Options:
+# - "clipboard": Allow the assistant to write to the clipboard when requested
+# - "time": Add the current time to the system prompt
+# Or create your own module in the "system_prompts\modules" folder, then add the name of the file here.
+ACTIVE_PROMPT_MODULES = ["clipboard", "time"]
 
 ### MISC ###
 AUDIO_FILE_DIR = "audio_files"

--- a/config_default.py
+++ b/config_default.py
@@ -97,8 +97,9 @@ ACTIVE_PROMPT = "default_prompt"
 # Options:
 # - "clipboard": Allow the assistant to write to the clipboard when requested
 # - "time": Add the current time to the system prompt
+# - "window_title": Add the current window title to the system prompt
 # Or create your own module in the "system_prompts\modules" folder, then add the name of the file here.
-ACTIVE_PROMPT_MODULES = ["clipboard", "time"]
+ACTIVE_PROMPT_MODULES = ["clipboard", "time", "window_title"]
 
 ### MISC ###
 AUDIO_FILE_DIR = "audio_files"

--- a/config_default.py
+++ b/config_default.py
@@ -88,8 +88,8 @@ PIPER_VOICE_SPEED = 1.0 # Speed of the TTS, 1.0 is normal speed, 2.0 is double s
 
 ### PROMPTS ###
 # Options:
-# - "default_prompt": Straight to the point assistant that can write to your clipboard when requested.
-# - "chat_prompt": Simple prompt for a friendly back-and-forth chat. Does NOT support writing to clipboard.
+# - "default_prompt": Straight to the point assistant.
+# - "chat_prompt": Friendly back-and-forth chat.
 # - None: No system prompt, for the raw out-of-the-box model behavior.
 # Or create your own prompt in the "system_prompts" folder, then put the name of the file here.
 ACTIVE_PROMPT = "default_prompt"

--- a/prompt.py
+++ b/prompt.py
@@ -1,4 +1,5 @@
 import importlib
+import config
 
 
 def build_initial_messages(prompt_name):
@@ -28,4 +29,9 @@ def get_system_prompt_message(prompt_name):
             print(f"Error: System prompt '{prompt_name}' not found. Using default prompt.")
             system_prompt = importlib.import_module("system_prompts.default_prompt")
 
-        return system_prompt.get_prompt()
+        prompt = system_prompt.get_prompt().strip()
+
+        for module in config.ACTIVE_PROMPT_MODULES:
+            prompt += "\n\n" + importlib.import_module(f"system_prompts.modules.{module}").get_prompt().strip()
+
+        return prompt

--- a/system_prompts/chat_prompt.py
+++ b/system_prompts/chat_prompt.py
@@ -1,11 +1,7 @@
-from datetime import datetime
-
-def get_prompt(): return f'''Instructions on how you should behave:
+def get_prompt(): return f'''
+Instructions on how you should behave:
 - Avoid asking the user how you can assist or help them; instead, casually ask a question to initiate or continue a conversation.
 - Maintain a friendly and informal tone.
 - Your responses are read aloud via TTS, so respond in clear and engaging prose.
 - Keep your average response length to 1-2 sentences.
-- Ask only one question at a time.
-
-Current date: {datetime.now().strftime("%Y-%m-%d (%A)")}
-Current time: {datetime.now().strftime("%H:%M")}'''
+- Ask only one question at a time.'''

--- a/system_prompts/default_prompt.py
+++ b/system_prompts/default_prompt.py
@@ -1,33 +1,9 @@
-from config_loader import config
-from datetime import datetime
-
-
-def get_prompt(): return f'''Instructions on how you should behave:
+def get_prompt(): return f'''
+Instructions on how you should behave:
 - Do not ask the user how you can assist or help them.
 - Do not explain that you are an AI assistant.
 - When asked a question, provide directly relevant information without any unnecessary details.
 - Your responses are read aloud via TTS, so respond in short clear prose with zero fluff. Avoid long messages and lists.
 - Your average response length should be 1-2 sentences.
 - Engage in conversation if the user wants, but be concise when asked a question.
-
-Current date: {datetime.now().strftime("%Y-%m-%d (%A)")}
-Current time: {datetime.now().strftime("%H:%M")}
-
-The user may give you access to read from their clipboard if they double tap the record hotkey.
-
-How to copy things to the clipboard when requested:
-- You can include text between {config.CLIPBOARD_TEXT_START_SEQ} and {config.CLIPBOARD_TEXT_END_SEQ} to copy it to the clipboard.
-- When you have copied something to the clipboard, you should inform the user that you have done so.
-- Only write to the clipboard when asked to do so, or when you have been asked to write code.
-
-- Abstract multiline example:
-{config.CLIPBOARD_TEXT_START_SEQ}
-CLIPBOARD TEXT LINE 1 HERE
-CLIPBOARD TEXT LINE 2 HERE
-{config.CLIPBOARD_TEXT_END_SEQ}
-I have copied the text to your clipboard.
-
-- Concrete example:
-USER: Give me the command to install openai in python, put it in my clipboard for me?
-YOU: {config.CLIPBOARD_TEXT_START_SEQ} pip install openai {config.CLIPBOARD_TEXT_END_SEQ}
-I have copied the command to install OpenAI in Python to your clipboard.'''
+'''

--- a/system_prompts/modules/clipboard.py
+++ b/system_prompts/modules/clipboard.py
@@ -1,0 +1,22 @@
+import config
+
+def get_prompt(): return f'''
+The user may give you access to read from their clipboard if they double tap the record hotkey.
+
+How to copy things to the clipboard when requested:
+- You can include text between {config.CLIPBOARD_TEXT_START_SEQ} and {config.CLIPBOARD_TEXT_END_SEQ} to copy it to the clipboard.
+- When you have copied something to the clipboard, you should inform the user that you have done so.
+- Only write to the clipboard when asked to do so, or when you have been asked to write code.
+
+- Abstract multiline example:
+{config.CLIPBOARD_TEXT_START_SEQ}
+CLIPBOARD TEXT LINE 1 HERE
+CLIPBOARD TEXT LINE 2 HERE
+{config.CLIPBOARD_TEXT_END_SEQ}
+I have copied the text to your clipboard.
+
+- Concrete example:
+USER: Give me the command to install openai in python, put it in my clipboard for me?
+YOU: {config.CLIPBOARD_TEXT_START_SEQ} pip install openai {config.CLIPBOARD_TEXT_END_SEQ}
+I have copied the command to install OpenAI in Python to your clipboard.
+'''

--- a/system_prompts/modules/time.py
+++ b/system_prompts/modules/time.py
@@ -1,0 +1,6 @@
+from datetime import datetime
+
+def get_prompt(): return f'''
+Current date: {datetime.now().strftime("%Y-%m-%d (%A)")}
+Current time: {datetime.now().strftime("%H:%M")}
+'''

--- a/system_prompts/modules/window_title.py
+++ b/system_prompts/modules/window_title.py
@@ -1,0 +1,5 @@
+import pygetwindow as gw
+
+def get_prompt(): return f'''
+Current window title: {gw.getActiveWindowTitle()}
+'''


### PR DESCRIPTION
Modular System Prompt
---
I have separated the clipboard instructions and the date/time fetching of the default_prompt into two separate "modules". Users can from config.py select what combination of these to include, while the default_prompt.py and chat_prompt.py now only focus on the basic behavioural instructions.

Just like with the prompt files, users can very easily add new modules by copying and editing an existing one in the `system_prompts\modules` directory. Then include it by appending their new file to the new config.py option:

```py
# Options:
# - "clipboard": Allow the assistant to write to the clipboard when requested
# - "time": Add the current time to the system prompt
# - "window_title": Add the current window title to the system prompt
# Or create your own module in the "system_prompts\modules" folder, then add the name of the file here.
ACTIVE_PROMPT_MODULES = ["clipboard", "time", "window_title", "user_custom_module"]
```

Window Title Module
---
I also made a entirely new module that give the assistant the name of the currently focused window title. This often includes relevant information, such as when watching a YouTube video, the video title is included in the window title, so the assistant takes that into context.

This gives the ability to simply ask "Do you know what this is about?" in a new chat while the YouTube page is in focus, and the assistant will respond using the video title as the topic context.